### PR TITLE
[AL-2885] Fix crash while adding members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ### Enhancements
 
 ### Fixes
+
+- [AL-2885] Fixed a crash when tapping on add member in Create group screen.

--- a/Sources/Controllers/ALKCreateGroupViewController.swift
+++ b/Sources/Controllers/ALKCreateGroupViewController.swift
@@ -256,6 +256,7 @@ final class ALKCreateGroupViewController: ALKBaseViewController {
             let selectParticipantViewController = segue.destination as? ALKSelectParticipantToAddViewController
             selectParticipantViewController?.selectParticipantDelegate = self
             selectParticipantViewController?.friendsInGroup = self.groupList
+            selectParticipantViewController?.configuration = configuration
         }
     }
 
@@ -324,8 +325,6 @@ extension ALKCreateGroupViewController:ALKAddParticipantProtocol
         if (atIndex.row == self.groupList.count || self.groupList.count == 0) {
             txtfGroupName.resignFirstResponder()
             self.performSegue(withIdentifier: "goToSelectFriendToAdd", sender: nil)
-        } else {
-            //do nothing yet
         }
     }
 


### PR DESCRIPTION
Fixes an issue which app crashes due to the `configuration`'s value being nil.