### PR TITLE
[AL-2908] Fix message character going out of bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Also see the [releases](https://github.com/AppLozic/ApplozicSwift/releases) on Github.
 
-0.15.0 (upcoming release)
+0.16.0 (upcoming release)
+---
+### Enhancements
+
+
+### Fixes
+
+- [AL-2908] Fixed message character going out of bounds
+
+
+0.15.0
 ---
 ### Enhancements
 

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -381,7 +381,7 @@ open class ALKChatBar: UIView {
         poweredByMessageLabel.bottomAnchor.constraint(equalTo: textView.topAnchor).isActive = true
         poweredByMessageLabel.topAnchor.constraint(equalTo: topAnchor).isActive = true
 
-        textView.trailingAnchor.constraint(equalTo: sendButton.leadingAnchor).isActive = true
+        textView.trailingAnchor.constraint(equalTo: lineImageView.leadingAnchor).isActive = true
         
         textViewHeighConstrain = textView.heightAnchor.constraint(equalToConstant: textViewHeigh)
         textViewHeighConstrain?.isActive = true


### PR DESCRIPTION
This fixes characters going outside message textview boundary while typing long messages