### PR TITLE
[AL-2932] Fix removal of group from chat list after leaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Also see the [releases](https://github.com/AppLozic/ApplozicSwift/releases) on Github.
 
+
 1.0.1(upcoming release)
 ---
 ### Enhancements
 
 ### Fixes
-- Fix position of audio-mic button. When coming back from photos screen or location screen position of mic button moves to left of screen.
-
+- [AL-2932] Fix removal of group from chat list after group is left by swiping right on group.
 
 1.0.0
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Also see the [releases](https://github.com/AppLozic/ApplozicSwift/releases) on Github.
 
-
 1.0.1(upcoming release)
 ---
 ### Enhancements
 
 ### Fixes
+- Fix position of audio-mic button. When coming back from photos screen or location screen position of mic button moves to left of screen.
 - [AL-2932] Fix removal of group from chat list after group is left by swiping right on group.
 
 1.0.0

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -592,15 +592,25 @@ extension ALKConversationListViewController: ALKChatCellDelegate {
 
             //TODO: Add activity indicator
 
+            
+            let deleteGroupPopupMessage = NSLocalizedString("DeleteGroupConversation", value: SystemMessage.Warning.DeleteGroupConversation, comment: "")
+            let leaveGroupPopupMessage = NSLocalizedString("DeleteGroupConversation", value: SystemMessage.Warning.LeaveGroupConoversation, comment: "")
+            let deleteSingleConversationPopupMessage = NSLocalizedString("DeleteSingleConversation", value: SystemMessage.Warning.DeleteSingleConversation, comment: "")
+            
+            let removeButtonText = NSLocalizedString("ButtonRemove", value: SystemMessage.ButtonName.Remove, comment: "")
+            let leaveButtonText = NSLocalizedString("ButtonLeave", value: SystemMessage.ButtonName.Leave, comment: "")
+            
             if searchActive {
                 guard let conversation = searchFilteredChat[indexPath.row] as? ALMessage else {return}
-
-                let prefixText = conversation.isGroupChat ? NSLocalizedString("DeleteGroupConversation", value: SystemMessage.Warning.DeleteGroupConversation, comment: "") : NSLocalizedString("DeleteSingleConversation", value: SystemMessage.Warning.DeleteSingleConversation, comment: "")
+                let isChannelLeft = ALChannelService().isChannelLeft(conversation.groupId)
+                let prefixText = conversation.isGroupChat ?(isChannelLeft ?  deleteGroupPopupMessage : leaveGroupPopupMessage) : deleteSingleConversationPopupMessage
+                
                 let name = conversation.isGroupChat ? conversation.groupName : conversation.name
                 let text = "\(prefixText) \(name)?"
                 let alert = UIAlertController(title: nil, message: text, preferredStyle: .alert)
                 let cancelButton = UIAlertAction(title: NSLocalizedString("ButtonCancel", value: SystemMessage.ButtonName.Cancel, comment: ""), style: .cancel, handler: nil)
-                let deleteButton = UIAlertAction(title: NSLocalizedString("ButtonRemove", value: SystemMessage.ButtonName.Remove, comment: ""), style: .destructive, handler: { [weak self] (alert) in
+                let buttonTitle = conversation.isGroupChat ? (isChannelLeft ? removeButtonText : leaveButtonText) : removeButtonText
+                let deleteButton = UIAlertAction(title: buttonTitle, style: .destructive, handler: { [weak self] (alert) in
                     guard let weakSelf = self, ALDataNetworkConnection.checkDataNetworkAvailable() else { return }
 
                     if conversation.isGroupChat {
@@ -623,8 +633,6 @@ extension ALKConversationListViewController: ALKChatCellDelegate {
                                 ALMessageService.deleteMessageThread(nil, orChannelKey: conversation.groupId, withCompletion: {
                                     _,error in
                                     guard error == nil else { return }
-                                    weakSelf.searchFilteredChat.remove(at: indexPath.row)
-                                    weakSelf.viewModel.remove(message: conversation)
                                     weakSelf.tableView.reloadData()
                                     return
                                 })
@@ -644,13 +652,15 @@ extension ALKConversationListViewController: ALKChatCellDelegate {
                 present(alert, animated: true, completion: nil)
             }
             else if let _ = self.viewModel.chatForRow(indexPath: indexPath), let conversation = self.viewModel.getChatList()[indexPath.row] as? ALMessage {
-
-                let prefixText = conversation.isGroupChat ? NSLocalizedString("DeleteGroupConversation", value: SystemMessage.Warning.DeleteGroupConversation, comment: "") : NSLocalizedString("DeleteSingleConversation", value: SystemMessage.Warning.DeleteSingleConversation, comment: "")
+                let isChannelLeft = ALChannelService().isChannelLeft(conversation.groupId)
+                let prefixText = conversation.isGroupChat ?(isChannelLeft ?  deleteGroupPopupMessage : leaveGroupPopupMessage) : deleteSingleConversationPopupMessage
+                
                 let name = conversation.isGroupChat ? conversation.groupName : conversation.name
                 let text = "\(prefixText) \(name)?"
                 let alert = UIAlertController(title: nil, message: text, preferredStyle: .alert)
                 let cancelBotton = UIAlertAction(title: NSLocalizedString("ButtonCancel", value: SystemMessage.ButtonName.Cancel, comment: ""), style: .cancel, handler: nil)
-                let deleteBotton = UIAlertAction(title: NSLocalizedString("ButtonRemove", value: SystemMessage.ButtonName.Remove, comment: ""), style: .destructive, handler: { [weak self] (alert) in
+                let buttonTitle = conversation.isGroupChat ? (isChannelLeft ? removeButtonText : leaveButtonText) : removeButtonText
+                let deleteBotton = UIAlertAction(title: buttonTitle, style: .destructive, handler: { [weak self] (alert) in
                     guard let weakSelf = self else { return }
                     if conversation.isGroupChat {
                         let channelService = ALChannelService()
@@ -670,7 +680,6 @@ extension ALKConversationListViewController: ALKChatCellDelegate {
                                 ALMessageService.deleteMessageThread(nil, orChannelKey: conversation.groupId, withCompletion: {
                                     _,error in
                                     guard error == nil else { return }
-                                    weakSelf.viewModel.remove(message: conversation)
                                     weakSelf.tableView.reloadData()
                                     return
                                 })

--- a/Sources/Utilities/SystemMessage.swift
+++ b/Sources/Utilities/SystemMessage.swift
@@ -59,6 +59,7 @@ struct SystemMessage {
         static let FetchFail = "Fetch data failed. Please retry again"
         static let OperationFail = "Operation could not be completed. Please retry again"
         static let DeleteSingleConversation = "Are you sure you want to remove the chat with"
+        static let LeaveGroupConoversation = "Are you sure you want to leave the group"
         static let DeleteGroupConversation = "Are you sure you want to remove the group"
         static let DeleteContactWith = "Are you sure you want to remove"
         static let DownloadOriginalImageFail = "Fail to download the original image"
@@ -70,6 +71,7 @@ struct SystemMessage {
         static let SignOut = "Sign out"
         static let Retry = "Retry"
         static let Remove = "Remove"
+        static let Leave = "Leave"
         static let Cancel = "Cancel"
         static let Discard = "Discard"
     }


### PR DESCRIPTION
Swipe right on group chat is used to leave group and delete group both. 
This PR will add distinction between the messages when group is swiped right, indicating whether it is to leave group or delete group. 
Also it will fix group disappearing from list when group is left.