### PR TITLE
[Al-2978] Fix overlap of new message with group messages in chatList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - Fix position of audio-mic button. When coming back from photos screen or location screen position of mic button moves to left of screen.
 - [AL-2932] Fix removal of group from chat list after group is left by swiping right on group.
 - [AL-2920] Fix an issue where chat, opened from tapping on push notification, won't scroll to latest message.
+- [AL-2978] Fix an issue where new one to one chat from a user would overlap all the groupChats in which this user has sent last message.
 
 1.0.0
 ---

--- a/Sources/ViewModels/ALKConversationListViewModel.swift
+++ b/Sources/ViewModels/ALKConversationListViewModel.swift
@@ -96,7 +96,9 @@ final public class ALKConversationListViewModel: NSObject {
             if let _ = currentMessage.groupId {
                 messagePresent = allMessages.filter { ($0.groupId != nil) ? $0.groupId == currentMessage.groupId:false }
             } else {
-                messagePresent = allMessages.filter { ($0.contactId != nil) ? $0.contactId == currentMessage.contactId:false }
+                messagePresent = allMessages.filter {
+                    $0.groupId == nil ? (($0.contactId != nil) ? $0.contactId == currentMessage.contactId:false) : false
+                }
             }
 
             if let firstElement = messagePresent.first, let index = allMessages.index(of: firstElement)  {


### PR DESCRIPTION
When a new message comes from a user,then all the group messages where this user has sent the last message will get overlapped.