### PR TITLE
Fix crash when chat opened on tap of notification #trivial

### DIFF
--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -481,28 +481,35 @@ extension ALKConversationListViewController: ALMQTTConversationDelegate {
         }
         return false
     }
+    
+    func isMessageSentByLoggedInUser(alMessage: ALMessage) -> Bool {
+        if ALUserDefaultsHandler.getUserId() == alMessage.contactId {
+            return true
+        }
+        return false
+    }
 
 
     open func syncCall(_ alMessage: ALMessage!, andMessageList messageArray: NSMutableArray!) {
         print("sync call: ", alMessage.message)
         guard let message = alMessage else { return }
-        let viewController = conversationViewController
+        let viewController = self.navigationController?.visibleViewController  as? ALKConversationViewController
         if let vm = viewController?.viewModel, (vm.contactId != nil || vm.channelKey != nil),
             let visibleController = self.navigationController?.visibleViewController,
             visibleController.isKind(of: ALKConversationViewController.self),
             isNewMessageForActiveThread(alMessage: alMessage, vm: vm) {
                 viewModel.syncCall(viewController: viewController, message: message, isChatOpen: true)
 
-        } else {
+        } else if !isMessageSentByLoggedInUser(alMessage: alMessage){
             let notificationView = ALNotificationView(alMessage: message, withAlertMessage: message.message)
             notificationView?.showNativeNotificationWithcompletionHandler({
                 response in
                 self.launchChat(contactId: message.contactId, groupId: message.groupId, conversationId: message.conversationId)
             })
-            if let visibleController = self.navigationController?.visibleViewController,
-                visibleController.isKind(of: ALKConversationListViewController.self) {
-                sync(message: alMessage)
-            }
+        }
+        if let visibleController = self.navigationController?.visibleViewController,
+            visibleController.isKind(of: ALKConversationListViewController.self) {
+            sync(message: alMessage)
         }
     }
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -951,6 +951,9 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
     //And thats why when we check whether last cell is visible or not, it gives false result since the last cell is sometimes not fully visible.
     //This is a known apple bug and has a thread in stackoverflow: https://stackoverflow.com/questions/25686490/ios-8-auto-cell-height-cant-scroll-to-last-row
     private func moveTableViewToBottom(indexPath: IndexPath){
+        guard indexPath.section >= 0 else {
+            return
+        }
         tableView.scrollToRow(at: indexPath, at: UITableViewScrollPosition.bottom, animated: true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             self.tableView.scrollToRow(at: indexPath, at: UITableViewScrollPosition.bottom, animated: true)
@@ -962,7 +965,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         //Check if current user is removed from the group
         isChannelLeft()
 
-        if isViewLoadedFromTappingOnNotification{
+        if isViewLoadedFromTappingOnNotification {
             let indexPath: IndexPath = IndexPath(row: 0, section: viewModel.messageModels.count - 1)
             moveTableViewToBottom(indexPath: indexPath)
             isViewLoadedFromTappingOnNotification = false
@@ -970,7 +973,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
             if tableView.isCellVisible(section: viewModel.messageModels.count-2, row: 0) { //1 for recent added msg and 1 because it starts with 0
                 let indexPath: IndexPath = IndexPath(row: 0, section: viewModel.messageModels.count - 1)
                 moveTableViewToBottom(indexPath: indexPath)
-            } else {
+            } else if viewModel.messageModels.count > 1 { // Check if the function is called before message is added. It happens when user is added in the group.
                 unreadScrollButton.isHidden = false
             }
         }


### PR DESCRIPTION
This PR will add the following checks:

1. When sync call is called, use visible view controller, as conversationViewController can be null. 

2. moveTableViewToBottom shouldn't be called with negative indexPath section. It happened when user is added in the group. And app is opened from notification tap. So number of messages will be 0.

3. unreadScroll button shouldn't come when number of messages is just 1.
