### PR TITLE
[AL-3131] Update notification to support context-based-chat

### DIFF
--- a/ApplozicSwift.podspec
+++ b/ApplozicSwift.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'Kingfisher', '~> 4.7.0'
   s.dependency 'MGSwipeTableCell', '~> 1.5.6'
-  s.dependency 'Applozic', '~> 6.3.0'
+  s.dependency 'Applozic', '~> 6.6.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - [AL-2923] Added configure for hide back button in conversation list
 - [AL-2923] Added configure for changing  color in navigation title
 - [Al-3093] Update rich message layout to display message on top of templates.
+- [AL-3131] Update notification to support context-based-chat.
 
 ### Fixes
 

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,27 +1,27 @@
 PODS:
-  - Applozic (6.3.0):
+  - Applozic (6.6.1):
     - SDWebImage (~> 4.4)
   - ApplozicSwift (1.2.0):
-    - Applozic (~> 6.3.0)
+    - Applozic (~> 6.6.1)
     - Kingfisher (~> 4.7.0)
     - MGSwipeTableCell (~> 1.5.6)
-  - iOSSnapshotTestCase (4.0.0):
-    - iOSSnapshotTestCase/SwiftSupport (= 4.0.0)
-  - iOSSnapshotTestCase/Core (4.0.0)
-  - iOSSnapshotTestCase/SwiftSupport (4.0.0):
+  - iOSSnapshotTestCase (4.0.1):
+    - iOSSnapshotTestCase/SwiftSupport (= 4.0.1)
+  - iOSSnapshotTestCase/Core (4.0.1)
+  - iOSSnapshotTestCase/SwiftSupport (4.0.1):
     - iOSSnapshotTestCase/Core
   - Kingfisher (4.7.0)
   - MGSwipeTableCell (1.5.6)
   - Nimble (7.3.1)
-  - Nimble-Snapshots (6.8.1):
-    - Nimble-Snapshots/Core (= 6.8.1)
-  - Nimble-Snapshots/Core (6.8.1):
+  - Nimble-Snapshots (6.9.0):
+    - Nimble-Snapshots/Core (= 6.9.0)
+  - Nimble-Snapshots/Core (6.9.0):
     - iOSSnapshotTestCase (~> 4.0)
     - Nimble (~> 7.0)
   - Quick (1.3.2)
-  - SDWebImage (4.4.2):
-    - SDWebImage/Core (= 4.4.2)
-  - SDWebImage/Core (4.4.2)
+  - SDWebImage (4.4.3):
+    - SDWebImage/Core (= 4.4.3)
+  - SDWebImage/Core (4.4.3)
 
 DEPENDENCIES:
   - ApplozicSwift (from `../ApplozicSwift.podspec`)
@@ -45,15 +45,15 @@ EXTERNAL SOURCES:
     :path: "../ApplozicSwift.podspec"
 
 SPEC CHECKSUMS:
-  Applozic: 883d73d212ab7c92d8f51b7be1a3e0b335c6be8b
-  ApplozicSwift: 6279303cf00deedba131dddabe6e1afa0ec1f16d
-  iOSSnapshotTestCase: 711379b19f69a22c131527df862352c877c2773c
+  Applozic: 337be6caf5a7af1933e67b7da0c4b2eb4fbd193b
+  ApplozicSwift: 1348337f040a7ae13dad5505cc621392697b2c4e
+  iOSSnapshotTestCase: f3b2b7e606fe03fdbe49af84316bd235df32dc44
   Kingfisher: da6b005aa96d37698e3e4f1ccfe96a5b9bbf27d6
   MGSwipeTableCell: 616700eb0ffd1c611ba909066cb7fd739790a0a7
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
-  Nimble-Snapshots: 65bce321fa2f62d70909b90a66a825a3cc4ae773
+  Nimble-Snapshots: 79394f8d0aea3df54bd5ff78ee9dff05a523a09c
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
-  SDWebImage: 624d6e296c69b244bcede364c72ae0430ac14681
+  SDWebImage: c5594f1a19c48d526d321e548902b56b479cd508
 
 PODFILE CHECKSUM: 132ea2b243622fd1507bc328a3258f4b2f8d912e
 

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -106,6 +106,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
             } else if components.count == 2 {
                 let conversationComponent = Int(components[1])
                 conversationId = NSNumber(integerLiteral: conversationComponent!)
+                contactId = components[0]
             } else {
                 contactId = object
             }
@@ -128,7 +129,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
             } else if updateUI == Int(APP_STATE_INACTIVE.rawValue) {
                 // Coming from background
 
-                guard contactId != nil || groupId != nil else { return }
+                guard contactId != nil || groupId != nil || conversationId != nil else { return }
                weakSelf.launchChat(contactId: contactId, groupId: groupId, conversationId: conversationId)
             }
         })
@@ -384,12 +385,7 @@ extension ALKConversationListViewController: UITableViewDelegate, UITableViewDat
                 willSelectItemAt: indexPath.row,
                 viewController: self
             )
-            var conversationProxy: ALConversationProxy? = nil
-            let convService = ALConversationService()
-            if let convId = chat.conversationId, let convProxy = convService.getConversationByKey(convId) {
-                conversationProxy = convProxy
-            }
-            let convViewModel = conversationViewModelType.init(contactId: chat.contactId, channelKey: chat.channelKey, conversationProxy: conversationProxy, localizedStringFileName: configuration.localizedStringFileName)
+            let convViewModel = viewModel.conversationViewModelOf(type: conversationViewModelType, contactId: chat.contactId, channelId: chat.channelKey, conversationId: chat.conversationId)
             let viewController = conversationViewController ?? ALKConversationViewController(configuration: configuration)
             let chatName = chat.name.count > 0 ? chat.name : localizedString(forKey: "NoNameMessage", withDefaultValue: SystemMessage.NoData.NoName, fileName: localizedStringFileName)
             viewController.title = chat.isGroupChat ? chat.groupName:chatName
@@ -404,12 +400,7 @@ extension ALKConversationListViewController: UITableViewDelegate, UITableViewDat
                 willSelectItemAt: indexPath.row,
                 viewController: self
             )
-            var conversationProxy: ALConversationProxy? = nil
-            let convService = ALConversationService()
-            if let convId = chat.conversationId, let convProxy = convService.getConversationByKey(convId) {
-                conversationProxy = convProxy
-            }
-            let convViewModel = conversationViewModelType.init(contactId: chat.contactId, channelKey: chat.channelKey, conversationProxy: conversationProxy, localizedStringFileName: configuration.localizedStringFileName)
+            let convViewModel = viewModel.conversationViewModelOf(type: conversationViewModelType, contactId: chat.contactId, channelId: chat.channelKey, conversationId: chat.conversationId)
             let viewController = conversationViewController ?? ALKConversationViewController(configuration: configuration)
             viewController.title = chat.isGroupChat ? chat.groupName:chat.name
             viewController.viewModel = convViewModel

--- a/Sources/Utilities/ALKPushNotificationHandler.swift
+++ b/Sources/Utilities/ALKPushNotificationHandler.swift
@@ -50,6 +50,7 @@ public class ALKPushNotificationHandler: Localizable {
             self?.contactId = nil
             self?.groupId = nil
             self?.title = ""
+            self?.conversationId = nil
             //Todo: Handle group
 
             guard let weakSelf = self, let object = notification.object as? String else { return }
@@ -100,10 +101,7 @@ public class ALKPushNotificationHandler: Localizable {
         let messagesVC = ALKConversationListViewController(configuration: configuration)
         messagesVC.contactId = userId
         messagesVC.channelKey = groupId
-        
-        if self.conversationId != nil {
-            messagesVC.conversationId = self.conversationId
-        }
+        messagesVC.conversationId = self.conversationId
         
         let pushAssistant = ALPushAssist()
         let topVC =  pushAssistant.topViewController

--- a/Sources/Utilities/ALKPushNotificationHandler.swift
+++ b/Sources/Utilities/ALKPushNotificationHandler.swift
@@ -9,15 +9,15 @@
 import Foundation
 import Applozic
 
-public class ALKPushNotificationHandler {
+public class ALKPushNotificationHandler: Localizable {
     public static let shared = ALKPushNotificationHandler()
     var navVC: UINavigationController?
 
     var contactId: String?
     var groupId: NSNumber?
+    var conversationId: NSNumber?
     var title: String = ""
     var configuration: ALKConfiguration!
-
 
     private var alContact: ALContact? {
         let alContactDbService = ALContactDBService()
@@ -54,24 +54,33 @@ public class ALKPushNotificationHandler {
 
             guard let weakSelf = self, let object = notification.object as? String else { return }
             let components = object.components(separatedBy: ":")
-            if components.count > 1 {
+            
+            let noNameMessage = weakSelf.localizedString(forKey: "NoNameMessage", withDefaultValue: SystemMessage.NoData.NoName, fileName: configuration.localizedStringFileName)
+            
+            if components.count > 2 {
                 guard let componentElement = Int(components[1]) else { return }
                 let id = NSNumber(integerLiteral: componentElement)
                 weakSelf.groupId = id
                 guard let alChannel = weakSelf.alChannel, let name = alChannel.name else { return }
                 weakSelf.title = name
-
+            } else if components.count == 2 {
+                guard let conversationComponent = Int(components[1]) else { return }
+                weakSelf.conversationId = NSNumber(integerLiteral: conversationComponent)
+                weakSelf.contactId = components[0]
+                guard let alContact = weakSelf.alContact else { return }
+                weakSelf.title = alContact.getDisplayName() ?? noNameMessage
             } else {
                 weakSelf.contactId = object
                 guard let alContact = weakSelf.alContact else { return }
-                let displayName = alContact.getDisplayName() ?? "No name"
+                let displayName = alContact.getDisplayName() ?? noNameMessage
                 weakSelf.title = displayName
             }
-
+            
             if UIApplication.shared.applicationState == .active {
                 guard let userInfo = notification.userInfo, let alertValue = userInfo["alertValue"] as? String else {
                         return
                 }
+                ///TODO: FIX HERE. USE conversationId also. 
                 ALUtilityClass.thirdDisplayNotificationTS(alertValue, andForContactId: weakSelf.contactId, withGroupId: weakSelf.groupId, completionHandler: {
 
                     _ in
@@ -91,6 +100,11 @@ public class ALKPushNotificationHandler {
         let messagesVC = ALKConversationListViewController(configuration: configuration)
         messagesVC.contactId = userId
         messagesVC.channelKey = groupId
+        
+        if self.conversationId != nil {
+            messagesVC.conversationId = self.conversationId
+        }
+        
         let pushAssistant = ALPushAssist()
         let topVC =  pushAssistant.topViewController
         let nav = ALKBaseNavigationViewController(rootViewController: messagesVC)


### PR DESCRIPTION
This PR will update notification to include conversationId so that context-based-chat can be displayed correctly after tapping on notification. 
It also updates Applozic dependency to 6.6.1.