### PR TITLE
Fix loading of earlier messages for group #trivial

### DIFF
--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -306,7 +306,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             loadOpenGroupMessages()
             return
         }
-        var id = self.contactId ?? self.channelKey?.stringValue
+        var id = self.channelKey?.stringValue ?? self.contactId 
         if let convId = conversationId {
             id = convId.stringValue
         }


### PR DESCRIPTION
Use channel key first. In case channel key is absent then use contactId. 
