### PR TITLE
Enable chat even if user is not in group #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 -[Al-3137] Change quick reply view to a staggered grid layout.
 
 ### Fixes
+- Fixed an issue where view was taking time in moving upwards when keyboard appears in the screen.
 
 2.0.0
 ---

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -160,12 +160,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 weakSelf.keyboardSize = keyboardSize
 
                 let tableView = weakSelf.tableView
-                let isAtBotom = tableView.isAtBottom
-                let isJustSent = weakSelf.isJustSent
-
-                let view = weakSelf.view
-                _ = weakSelf.navigationController
-
 
                 var h = CGFloat(0)
                 h = keyboardSize.height-h
@@ -175,16 +169,14 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
                 weakSelf.bottomConstraint?.constant = newH
 
-                let duration = (notification.userInfo?[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0.05
+                weakSelf.view?.layoutIfNeeded()
 
-                UIView.animate(withDuration: duration, animations: {
-                    view?.layoutIfNeeded()
-                }, completion: { (_) in
-                    print("animated ")
-                    if isAtBotom == true && isJustSent == false {
-                        tableView.scrollToBottomByOfset(animated: false)
-                    }
-                })
+                if tableView.isCellVisible(section: weakSelf.viewModel.messageModels.count-1, row: 0) {
+                    tableView.scrollToBottomByOfset(animated: false)
+                } else if weakSelf.viewModel.messageModels.count > 1 {
+                    weakSelf.unreadScrollButton.isHidden = false
+                }
+
             }
         })
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -367,6 +367,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     override func backTapped() {
         print("back tapped")
+        view.endEditing(true)
         self.viewModel.sendKeyboardDoneTyping()
         _ = navigationController?.popToRootViewController(animated: true)
     }
@@ -405,7 +406,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         guard let channelKey = viewModel.channelKey, let channel = ALChannelService().getChannelByKey(channelKey) else {
             return
         }
-        if  channel.type != 6 && !ALChannelService().isLoginUser(inChannel: channelKey) {
+        if  channel.type != 6 && channel.type != 10 && !ALChannelService().isLoginUser(inChannel: channelKey) {
             chatBar.disableChat()
             //Disable click on toolbar
             titleButton.isUserInteractionEnabled = false

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -986,7 +986,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         let newSectionCount = tableView.numberOfSections
         if newSectionCount > oldSectionCount {
             let offset = newSectionCount - oldSectionCount - 1
-            tableView.scrollToRow(at: IndexPath(row: 0, section: offset), at: .none, animated: true)
+            tableView.scrollToRow(at: IndexPath(row: 0, section: offset), at: .none, animated: false)
         }
         print("loading finished")
         DispatchQueue.main.async {

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -98,6 +98,9 @@ public struct ALKConfiguration {
     /// Additional information you can pass in message metadata in all the messages.
     public var messageMetadata : [AnyHashable : Any]?
 
+    /// Set this value if you want to get custom metadata on quick reply messages.
+    public var quickReplyMetadataKey: String?
+
     /// Status bar style. It will be used in all view controllers.
     /// Default value is lightContent.
     public var statusBarStyle: UIStatusBarStyle = .lightContent {


### PR DESCRIPTION
This PR will do:
1. Allow user to chat for support group even if user is not present in the group. 
2. Fix keyboard show and hide UI in ALKConversationViewController.
3. When loading more messages, table view scroll animation was set to true which was causing noticeable differences in UI so updated the animation to false.