### PR TITLE
[AL-3196] Add a config option to disable the rich message button clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Also see the [releases](https://github.com/AppLozic/ApplozicSwift/releases) on Github.
 
+2.2.0(upcoming release)
+---
+### Enhancments
+
+-[AL-3196] Add a config option to disable the rich message button clicks.
+
 2.1.0
 ---
 ### Enhancements

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -298,8 +298,15 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                     return cell
                 }
                 cell.quickReplyView.quickReplySelected = {[weak self] tag, title, metadata in
-                    guard let index = tag else { return }
-                    self?.quickReplySelected(index: index, title: title, template: template, message: message, metadata: metadata)
+                    guard let weakSelf = self,
+                        let index = tag else { return }
+                    weakSelf.quickReplySelected(
+                        index: index,
+                        title: title,
+                        template: template,
+                        message: message,
+                        metadata: metadata,
+                        isButtonClickDisabled: weakSelf.configuration.disableRichMessageButtonAction)
                 }
                 return cell
             }
@@ -317,7 +324,12 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 cell.update(viewModel: message, maxWidth: UIScreen.main.bounds.width)
                 cell.update(chatBar: self.chatBar)
                 cell.buttonView.buttonSelected = {[weak self] index, title in
-                    self?.messageButtonSelected(index: index, title: title, message: message)
+                    guard let weakSelf = self else { return }
+                    weakSelf.messageButtonSelected(
+                        index: index,
+                        title: title,
+                        message: message,
+                        isButtonClickDisabled: weakSelf.configuration.disableRichMessageButtonAction)
                 }
                 return cell
             }

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -880,9 +880,17 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         NotificationCenter.default.post(name: Notification.Name(rawValue: "GenericRichListButtonSelected"), object: infoDict)
     }
 
-    func quickReplySelected(index: Int, title: String, template: [Dictionary<String, Any>], message: ALKMessageViewModel, metadata: Dictionary<String, Any>?) {
+    func quickReplySelected(
+        index: Int,
+        title: String,
+        template: [Dictionary<String, Any>],
+        message: ALKMessageViewModel,
+        metadata: Dictionary<String, Any>?,
+        isButtonClickDisabled: Bool) {
         print("\(title, index) quick reply button selected")
         sendNotification(withName: "QuickReplyButtonSelected", buttonName: title, buttonIndex: index, template: template)
+
+        guard !isButtonClickDisabled else { return }
 
         /// Get message to send
         guard index <= template.count && index > 0 else { return }
@@ -899,10 +907,13 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         viewModel.send(message: msg, metadata: customMetadata)
     }
 
-    func messageButtonSelected(index: Int, title: String, message: ALKMessageViewModel) {
-        guard
-            let dict = message.payloadFromMetadata(),
-            let selectedButton = dict[index] as? Dictionary<String, Any>,
+    func messageButtonSelected(
+        index: Int,
+        title: String,
+        message: ALKMessageViewModel,
+        isButtonClickDisabled: Bool) {
+        guard !isButtonClickDisabled,
+            let selectedButton = message.payloadFromMetadata()?[index],
             let buttonTitle = selectedButton["name"] as? String,
             buttonTitle == title
             else {

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -109,5 +109,11 @@ public struct ALKConfiguration {
         }
     }
 
+    /// If true then the all the buttons in messages of type Quick replies,
+    /// Generic Cards, Lists etc. will be disabled.
+    /// USAGE: It can be used in cases where your app supports multiple types
+    /// of users and you want to disable the buttons for a particular type of users.
+    public var disableRichMessageButtonAction = false
+
     public init() { }
 }


### PR DESCRIPTION
If the config option `disableRichMessageButtonAction`  is true then all the actions on click of rich message buttons like sending a message or opening a URL will be disabled.