### PR TITLE
Add a way to configure chat-cell outside SDK #trivial

### DIFF
--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListVCMemoryLeakTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListVCMemoryLeakTests.swift
@@ -28,7 +28,7 @@ class ALKConversationListVCMemoryLeakTests: QuickSpec {
 
                     // Pass all mocks
                     conversationListVC.viewModel = conversationListVM
-                    conversationListVC.dbServiceType = ALMessageDBServiceMock.self
+                    conversationListVC.dbService = ALMessageDBServiceMock()
                     conversationListVC.conversationViewController = conversationVC
                     conversationListVC.onDeinitialized = {
                         done()

--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListViewControllerTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListViewControllerTests.swift
@@ -71,7 +71,7 @@ class ALKConversationListViewControllerTests: XCTestCase {
         // Pass all mocks
         conversationListVC.viewModel = conversationListVM
         conversationListVC.delegate = conversation
-        conversationListVC.dbServiceType = ALMessageDBServiceMock.self
+        conversationListVC.dbService = ALMessageDBServiceMock()
         conversationListVC.conversationViewController = conversationVC
 
         // Select first thread

--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationViewControllerListSnapShotTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationViewControllerListSnapShotTests.swift
@@ -24,7 +24,7 @@ class ALKConversationViewControllerListSnapShotTests: QuickSpec {
             beforeEach {
 
                 conversationVC = ALKConversationListViewController(configuration: ALKConfiguration())
-                conversationVC.dbServiceType = ALMessageDBServiceMock.self
+                conversationVC.dbService = ALMessageDBServiceMock()
                 let firstMessage = ALKConversationViewModelMock.getMessageToPost()
                 firstMessage.message = "first message"
                 let secondmessage = ALKConversationViewModelMock.getMessageToPost()
@@ -32,6 +32,8 @@ class ALKConversationViewControllerListSnapShotTests: QuickSpec {
                 ALKConversationViewModelMock.testMessages = [firstMessage.messageModel, secondmessage.messageModel]
                 conversationVC.conversationViewModelType = ALKConversationViewModelMock.self
                 navigationController = ALKBaseNavigationViewController(rootViewController: conversationVC)
+                conversationVC.beginAppearanceTransition(true, animated: false)
+                conversationVC.endAppearanceTransition()
             }
 
             it("Show list") {
@@ -41,8 +43,6 @@ class ALKConversationViewControllerListSnapShotTests: QuickSpec {
             }
 
             it("Open chat thread") {
-                conversationVC.beginAppearanceTransition(true, animated: false)
-                conversationVC.endAppearanceTransition()
                 XCTAssertNotNil(conversationVC.tableView)
                 guard let tableView = conversationVC.tableView else {
                     return
@@ -63,7 +63,7 @@ class ALKConversationViewControllerListSnapShotTests: QuickSpec {
                 configuration = ALKConfiguration()
                 configuration.rightNavBarImageForConversationListView = UIImage(named: "close", in: Bundle.applozic, compatibleWith: nil)
                 conversationVC = ALKConversationListViewController(configuration: configuration)
-                conversationVC.dbServiceType = ALMessageDBServiceMock.self
+                conversationVC.dbService = ALMessageDBServiceMock()
                 conversationVC.conversationViewModelType = ALKConversationViewModelMock.self
                 conversationVC.beginAppearanceTransition(true, animated: false)
                 conversationVC.endAppearanceTransition()

--- a/Sources/Controllers/ALKConversationListTableViewController.swift
+++ b/Sources/Controllers/ALKConversationListTableViewController.swift
@@ -33,18 +33,18 @@ public class ALKConversationListTableViewController: UITableViewController, Loca
     //MARK: - PUBLIC PROPERTIES
     public var viewModel: ALKConversationListViewModelProtocol
     public var dbService: ALMessageDBService!
-    
+    public lazy var dataSource = ConversationListTableViewDataSource(viewModel: self.viewModel, cellConfigurator: { (message, tableCell) in
+        let cell = tableCell as! ALKChatCell
+        cell.update(viewModel: message, identity: nil)
+        cell.chatCellDelegate = self
+    })
+
     //MARK: - PRIVATE PROPERTIES
     fileprivate weak var delegate: ALKConversationListTableViewDelegate?
     fileprivate var configuration: ALKConfiguration
     fileprivate var showSearch: Bool
     fileprivate var localizedStringFileName: String
     fileprivate var tapToDismiss: UITapGestureRecognizer!
-    fileprivate lazy var dataSource = ConversationListTableViewDataSource(viewModel: self.viewModel, cellConfigurator: { (message, tableCell) in
-        let cell = tableCell as! ALKChatCell
-        cell.update(viewModel: message, identity: nil)
-        cell.chatCellDelegate = self
-    })
     fileprivate let activityIndicator = UIActivityIndicatorView(style: UIActivityIndicatorView.Style.gray)
     fileprivate let searchController = UISearchController(searchResultsController: nil)
     fileprivate var searchActive : Bool = false
@@ -292,7 +292,7 @@ extension ALKConversationListTableViewController: UISearchResultsUpdating, UISea
 //MARK: - ALKChatCell DELEGATE
 extension ALKConversationListTableViewController: ALKChatCellDelegate {
     
-    func chatCell(cell: ALKChatCell, action: ALKChatCellAction, viewModel: ALKChatViewModelProtocol) {
+    public func chatCell(cell: ALKChatCell, action: ALKChatCellAction, viewModel: ALKChatViewModelProtocol) {
         
         switch action {
             

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -28,8 +28,8 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
     public var viewModelType = ALKConversationListViewModel.self
     public var conversationViewModelType = ALKConversationViewModel.self
     public weak var delegate: ALKConversationListDelegate?
+    public lazy var conversationListTableViewController = ALKConversationListTableViewController(viewModel: self.viewModel, dbService: self.dbService, configuration: self.configuration, delegate: self, showSearch: false)
 
-    fileprivate lazy var conversationListTableViewController = ALKConversationListTableViewController(viewModel: self.viewModel, dbService: self.dbService, configuration: self.configuration, delegate: self, showSearch: false)
     fileprivate var tapToDismiss:UITapGestureRecognizer!
     fileprivate var alMqttConversationService: ALMQTTConversationService!
     fileprivate var dbService: ALMessageDBService!
@@ -63,6 +63,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
         dbService.delegate = self
         viewModel = viewModelType.init()
         viewModel.delegate = self
+        viewModel.localizationFileName = configuration.localizedStringFileName
     }
 
     deinit {
@@ -179,12 +180,6 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
         alMqttConversationService = ALMQTTConversationService.sharedInstance()
         alMqttConversationService.mqttConversationDelegate = self
         alMqttConversationService.subscribeToConversation()
-        dbService = dbServiceType.init()
-        dbService.delegate = self
-        viewModel = viewModelType.init()
-        viewModel.delegate = self
-        viewModel.localizationFileName = configuration.localizedStringFileName
-        viewModel.prepareController(dbService: dbService)
         setupView()
     }
 

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -24,19 +24,13 @@ public protocol ALKConversationListDelegate: class {
 open class ALKConversationListViewController: ALKBaseViewController, Localizable {
 
     public var conversationViewController: ALKConversationViewController?
-    public var dbServiceType = ALMessageDBService.self
-    public var viewModelType = ALKConversationListViewModel.self
     public var conversationViewModelType = ALKConversationViewModel.self
     public weak var delegate: ALKConversationListDelegate?
     public lazy var conversationListTableViewController = ALKConversationListTableViewController(viewModel: self.viewModel, dbService: self.dbService, configuration: self.configuration, delegate: self, showSearch: false)
 
-    fileprivate var tapToDismiss:UITapGestureRecognizer!
-    fileprivate var alMqttConversationService: ALMQTTConversationService!
-    fileprivate var dbService: ALMessageDBService!
-    fileprivate let activityIndicator = UIActivityIndicatorView(style: UIActivityIndicatorView.Style.gray)
-    fileprivate var localizedStringFileName: String!
+    var dbService = ALMessageDBService()
+    var viewModel = ALKConversationListViewModel()
 
-    var viewModel: ALKConversationListViewModel!
     // To check if coming from push notification
     var contactId: String?
     var channelKey: NSNumber?
@@ -52,6 +46,11 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
         return barButton
     }()
 
+    fileprivate var tapToDismiss:UITapGestureRecognizer!
+    fileprivate var alMqttConversationService: ALMQTTConversationService!
+    fileprivate let activityIndicator = UIActivityIndicatorView(style: UIActivityIndicatorView.Style.gray)
+    fileprivate var localizedStringFileName: String!
+
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
@@ -59,10 +58,6 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
     required public init(configuration: ALKConfiguration) {
         super.init(configuration: configuration)
         self.localizedStringFileName = configuration.localizedStringFileName
-        dbService = dbServiceType.init()
-        dbService.delegate = self
-        viewModel = viewModelType.init()
-        viewModel.delegate = self
         viewModel.localizationFileName = configuration.localizedStringFileName
     }
 
@@ -74,11 +69,11 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
     override func addObserver() {
 
         NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "newMessageNotification"), object: nil, queue: nil, using: {[weak self] notification in
-            guard let weakSelf = self, let viewModel = weakSelf.viewModel else { return }
+            guard let weakSelf = self else { return }
             let msgArray = notification.object as? [ALMessage]
             print("new notification received: ", msgArray?.first?.message ?? "")
             guard let list = notification.object as? [Any], !list.isEmpty else { return }
-            viewModel.addMessages(messages: list)
+            weakSelf.viewModel.addMessages(messages: list)
 
         })
 
@@ -180,6 +175,8 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
         alMqttConversationService = ALMQTTConversationService.sharedInstance()
         alMqttConversationService.mqttConversationDelegate = self
         alMqttConversationService.subscribeToConversation()
+        dbService.delegate = self
+        viewModel.delegate = self
         setupView()
     }
 
@@ -257,9 +254,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
             print("Contact id matched1")
             viewController.viewModel.addMessagesToList([message])
         }
-        if let dbService = dbService {
-            viewModel.prepareController(dbService: dbService)
-        }
+        viewModel.prepareController(dbService: dbService)
     }
 
     @objc func customBackAction() {

--- a/Sources/Utilities/ALKIdentityProtocol.swift
+++ b/Sources/Utilities/ALKIdentityProtocol.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol ALKIdentityProtocol {
+public protocol ALKIdentityProtocol {
     
     var displayName: String {get}
     var displayPhoto: URL? {get}

--- a/Sources/Utilities/ConversationListTableViewDataSource.swift
+++ b/Sources/Utilities/ConversationListTableViewDataSource.swift
@@ -8,15 +8,15 @@
 import Foundation
 import Applozic
 
-class ConversationListTableViewDataSource: NSObject, UITableViewDataSource {
+public class ConversationListTableViewDataSource: NSObject, UITableViewDataSource {
     
     /// A closure to configure tableview cell with the message object
-    typealias CellConfigurator = (ALKChatViewModelProtocol, UITableViewCell) -> Void
-    
+    public typealias CellConfigurator = (ALKChatViewModelProtocol, UITableViewCell) -> Void
+    public var cellConfigurator: CellConfigurator
+
     var viewModel: ALKConversationListViewModelProtocol
-    var cellConfigurator: CellConfigurator
-    
-    init(viewModel: ALKConversationListViewModelProtocol, cellConfigurator: @escaping CellConfigurator) {
+
+    public init(viewModel: ALKConversationListViewModelProtocol, cellConfigurator: @escaping CellConfigurator) {
         self.viewModel = viewModel
         self.cellConfigurator = cellConfigurator
     }
@@ -25,11 +25,11 @@ class ConversationListTableViewDataSource: NSObject, UITableViewDataSource {
         return viewModel.numberOfSections()
     }
     
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.numberOfRowsInSection(section)
     }
     
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let message = viewModel.chatFor(indexPath: indexPath) as? ALMessage else {
             return UITableViewCell()
         }

--- a/Sources/Views/ALKChatCell.swift
+++ b/Sources/Views/ALKChatCell.swift
@@ -1,6 +1,6 @@
 //
 //  ChatCell.swift
-//  
+//
 //
 //  Created by Mukesh Thawani on 04/05/17.
 //  Copyright © 2017 Applozic. All rights reserved.
@@ -28,7 +28,7 @@ public protocol ALKChatViewModelProtocol {
     var createdAt: String? { get }
 }
 
-enum ALKChatCellAction {
+public enum ALKChatCellAction {
     case delete
     case favorite
     case store
@@ -37,11 +37,11 @@ enum ALKChatCellAction {
     case unmute
 }
 
-protocol ALKChatCellDelegate: class {
+public protocol ALKChatCellDelegate: class {
     func chatCell(cell: ALKChatCell, action: ALKChatCellAction, viewModel: ALKChatViewModelProtocol)
 }
 
-final class ALKChatCell: MGSwipeTableCell {
+public final class ALKChatCell: MGSwipeTableCell {
 
     private var avatarImageView: UIImageView = {
         let imv = UIImageView()
@@ -127,10 +127,10 @@ final class ALKChatCell: MGSwipeTableCell {
         view.backgroundColor = UIColor.onlineGreen()
         return view
     }()
-    
+
     let muteButton: MGSwipeButton = MGSwipeButton.init(type: .custom)
 
-    weak var chatCellDelegate: ALKChatCellDelegate?
+    public weak var chatCellDelegate: ALKChatCellDelegate?
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -144,7 +144,7 @@ final class ALKChatCell: MGSwipeTableCell {
         //favoriteButton.removeTarget(self, action:  #selector(favoriteTapped(button:)), for: .touchUpInside)
     }
 
-    override func setHighlighted(_ highlighted: Bool, animated: Bool) {
+    override public func setHighlighted(_ highlighted: Bool, animated: Bool) {
         super.setHighlighted(highlighted, animated: animated)
 
         guard let _ = viewModel else {
@@ -160,7 +160,7 @@ final class ALKChatCell: MGSwipeTableCell {
         badgeNumberView.setBackgroundColor(.background(.main))
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
+    override public func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
 
         guard let _ = viewModel else {
@@ -176,7 +176,7 @@ final class ALKChatCell: MGSwipeTableCell {
         // set backgroundColor of badgeNumber
         badgeNumberView.setBackgroundColor(.background(.main))
     }
-    
+
     private func isConversationMuted(viewModel: ALKChatViewModelProtocol) -> Bool{
         if let channelKey = viewModel.channelKey,
             let channel = ALChannelService().getChannelByKey(channelKey){
@@ -197,10 +197,10 @@ final class ALKChatCell: MGSwipeTableCell {
             return true
         }
     }
-    
+
     var viewModel: ALKChatViewModelProtocol?
 
-    func update(viewModel: ALKChatViewModelProtocol, identity: ALKIdentityProtocol?, placeholder: UIImage? = nil) {
+    public func update(viewModel: ALKChatViewModelProtocol, identity: ALKIdentityProtocol?, placeholder: UIImage? = nil) {
 
         self.viewModel = viewModel
         let placeHolder = placeholderImage(placeholder, viewModel: viewModel)
@@ -246,13 +246,13 @@ final class ALKChatCell: MGSwipeTableCell {
         }else {
             muteButton.setImage(UIImage(named: "icon_mute_inactive", in: Bundle.applozic, compatibleWith: nil), for: .normal)
         }
- 
+
         muteButton.frame = CGRect.init(x: 0, y: 0, width: 69, height: 69)
         muteButton.callback = { [weak self] (buttnon) in
 
             guard let strongSelf = self else {return true}
             guard let viewModel = strongSelf.viewModel else {return true}
-            
+
             if strongSelf.isConversationMuted(viewModel: viewModel){
                 strongSelf.chatCellDelegate?.chatCell(cell: strongSelf, action: .unmute, viewModel: viewModel)
             }else {
@@ -279,7 +279,7 @@ final class ALKChatCell: MGSwipeTableCell {
         onlineStatusView.isHidden = true
 
         if !viewModel.isGroupChat {
-            
+
             let contactService = ALContactService()
             guard let contactId = viewModel.contactId,
             let contact = contactService.loadContact(byKey: "userId", value: contactId) else {
@@ -400,7 +400,7 @@ final class ALKChatCell: MGSwipeTableCell {
 //        comingSoonDelegate?.makeToast(SystemMessage.ComingSoon.Favorite, duration: 1.0, position: .center)
     }
 
-    override func setEditing(_ editing: Bool, animated: Bool) {
+    override public func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
     }
 
@@ -413,5 +413,5 @@ final class ALKChatCell: MGSwipeTableCell {
     func randomInt(min: Int, max:Int) -> Int {
         return min + Int(arc4random_uniform(UInt32(max - min + 1)))
     }
-    
+
 }


### PR DESCRIPTION
- This PR will add a way to configure conversation list cell outside the SDK.
- Code will only modify the access specifiers for different views and methods which will be used to configure cell. 
- Example to change cell :: 
> let conversationVC = ALKConversationListViewController(configuration: ALKConfiguration())
        conversationVC.conversationListTableViewController.dataSource.cellConfigurator = { (message, tableCell) in
            let cell = tableCell as! ALKChatCell
            cell.update(viewModel: message, identity: nil)
            cell.chatCellDelegate = conversationVC.conversationListTableViewController.self
        }

