### PR TITLE
[AL-3257] Add receive and sent message style 📱

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
         ALKMessageStyle.receivedBubble.style = .edge
 ```     
 - [AL-3229] Added caption support with image attachments. If the message(text) is present then it will be shown as caption.   
+- [AL-3257] Added receive and sent message style. This is how you can change the styles:
+
+```
+        ALKMessageStyle.receivedMessage = Style(font: Font.bold(size: 14).font(), text: UIColor.red)
+        ALKMessageStyle.sentMessage = Style(font: Font.italic(size: 14).font(), text: UIColor.green)
+```
+
 2.2.0
 ---
 ### Enhancments

--- a/Sources/Utilities/Message+Style.swift
+++ b/Sources/Utilities/Message+Style.swift
@@ -14,11 +14,6 @@ public enum ALKMessageStyle {
         text: .text(.gray9B)
     )
 
-    public static var message = Style(
-        font: UIFont.font(.normal(size: 14)),
-        text: .text(.black00)
-    )
-
     public static var playTime = Style(
         font: UIFont.font(.normal(size: 16)),
         text: .text(.black00)
@@ -28,6 +23,29 @@ public enum ALKMessageStyle {
         font: UIFont.font(.italic(size: 12)),
         text: .text(.grayCC)
     )
+
+    // Received message text style
+    public static var receivedMessage = Style(
+        font: UIFont.font(.normal(size: 14)),
+        text: .text(.black00)
+    )
+
+    // Sent message text style
+    public static var sentMessage = Style(
+        font: UIFont.font(.normal(size: 14)),
+        text: .text(.black00)
+    )
+
+    @available(*, deprecated, message: "Use `receivedMessage` and `sentMessage`")
+    public static var message = Style(
+        font: UIFont.font(.normal(size: 14)),
+        text: .text(.black00)
+    ) {
+        didSet {
+            receivedMessage = message
+            sentMessage = message
+        }
+    }
 
     public enum BubbleStyle {
         case edge

--- a/Sources/Views/ALKFriendMessageView.swift
+++ b/Sources/Views/ALKFriendMessageView.swift
@@ -131,7 +131,7 @@ class ALKFriendMessageView: UIView {
         nameLabel.text = viewModel.displayName
         nameLabel.setStyle(ALKMessageStyle.displayName)
         messageView.text = viewModel.message ?? ""
-        messageView.setStyle(ALKMessageStyle.message)
+        messageView.setStyle(ALKMessageStyle.receivedMessage)
         timeLabel.text = viewModel.time
         timeLabel.setStyle(ALKMessageStyle.time)
     }
@@ -141,7 +141,7 @@ class ALKFriendMessageView: UIView {
         guard let message = viewModel.message else {
             return minimumHeight
         }
-        let font = ALKMessageStyle.message.font
+        let font = ALKMessageStyle.receivedMessage.font
         let messageWidth = width - 64 // left padding 9 + 18 + 37
         var messageHeight = message.heightWithConstrainedWidth(width: messageWidth, font: font)
         messageHeight += 30 // 6 + 16 + 4 + 2 + 2
@@ -154,8 +154,8 @@ class ALKFriendMessageView: UIView {
         if let message = viewModel.message {
             let maxSize = CGSize.init(width: widthNoPadding, height: CGFloat.greatestFiniteMagnitude)
             
-            let font = ALKMessageStyle.message.font
-            let color = ALKMessageStyle.message.text
+            let font = ALKMessageStyle.receivedMessage.font
+            let color = ALKMessageStyle.receivedMessage.text
             
             let style = NSMutableParagraphStyle.init()
             style.lineBreakMode = .byWordWrapping

--- a/Sources/Views/ALKFriendPhotoCell.swift
+++ b/Sources/Views/ALKFriendPhotoCell.swift
@@ -41,10 +41,16 @@ class ALKFriendPhotoCell: ALKPhotoCell {
     override class func topPadding() -> CGFloat {
         return 28
     }
+
+    override class var messageTextFont: UIFont {
+        return ALKMessageStyle.receivedMessage.font
+    }
     
     override func setupStyle() {
         super.setupStyle()
         nameLabel.setStyle(ALKMessageStyle.displayName)
+        captionLabel.font = ALKMessageStyle.receivedMessage.font
+        captionLabel.textColor = ALKMessageStyle.receivedMessage.text
         if(ALKMessageStyle.receivedBubble.style == .edge){
             bubbleView.layer.cornerRadius = ALKMessageStyle.receivedBubble.cornerRadius
             bubbleView.backgroundColor = ALKMessageStyle.receivedBubble.color

--- a/Sources/Views/ALKMessageCell.swift
+++ b/Sources/Views/ALKMessageCell.swift
@@ -66,6 +66,10 @@ open class ALKFriendMessageCell: ALKMessageCell {
         case replyPreviewImageWidthIdentifier = "ReplyPreviewImageWidth"
     }
 
+    override class var messageTextFont: UIFont {
+        return ALKMessageStyle.receivedMessage.font
+    }
+
     override func setupViews() {
         super.setupViews()
 
@@ -163,6 +167,7 @@ open class ALKFriendMessageCell: ALKMessageCell {
         super.setupStyle()
 
         nameLabel.setStyle(ALKMessageStyle.displayName)
+        messageView.setStyle(ALKMessageStyle.receivedMessage)
         if ALKMessageStyle.receivedBubble.style == .edge {
             bubbleView.tintColor = UIColor(netHex: 0xF1F0F0)
             bubbleView.image = bubbleViewImage(for: ALKMessageStyle.receivedBubble.style, isReceiverSide: true,showHangOverImage: false)
@@ -321,6 +326,10 @@ open class ALKMyMessageCell: ALKMessageCell {
         static let replyViewHeightIdentifier = "ReplyViewHeight"
     }
 
+    override class var messageTextFont: UIFont {
+        return ALKMessageStyle.sentMessage.font
+    }
+
     override func setupViews() {
         super.setupViews()
 
@@ -394,6 +403,7 @@ open class ALKMyMessageCell: ALKMessageCell {
 
     open  override func setupStyle() {
         super.setupStyle()
+        messageView.setStyle(ALKMessageStyle.sentMessage)
         if ALKMessageStyle.sentBubble.style == .edge {
             bubbleView.tintColor = UIColor(netHex: 0xF1F0F0)
             bubbleView.image = bubbleViewImage(for: ALKMessageStyle.sentBubble.style, isReceiverSide: false,showHangOverImage: false)
@@ -550,6 +560,11 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
     }()
     var replyViewAction: (()->())? = nil
 
+    // To be changed from the class that is subclassing `ALKMessageCell`
+    class var messageTextFont: UIFont {
+        return Font.normal(size: 12).font()
+    }
+
     override func update(viewModel: ALKMessageViewModel) {
         self.viewModel = viewModel
 
@@ -615,8 +630,6 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
         super.setupStyle()
 
         timeLabel.setStyle(ALKMessageStyle.time)
-        messageView.setStyle(ALKMessageStyle.message)
-
     }
 
     class func leftPadding() -> CGFloat {
@@ -655,9 +668,6 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
             }
             let maxSize = CGSize.init(width: widthNoPadding, height: CGFloat.greatestFiniteMagnitude)
 
-            let font = ALKMessageStyle.message.font
-            let color = ALKMessageStyle.message.text
-
             let style = NSMutableParagraphStyle.init()
             style.lineBreakMode = .byWordWrapping
             style.headIndent = 0
@@ -667,8 +677,7 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
             style.maximumLineHeight = 17
 
             let attributes: [NSAttributedString.Key: Any] = [
-                NSAttributedString.Key.font: font,
-                NSAttributedString.Key.foregroundColor: color]
+                NSAttributedString.Key.font: messageTextFont]
 
             var size = CGSize()
             if viewModel.messageType == .html {

--- a/Sources/Views/ALKMyGenericListCell.swift
+++ b/Sources/Views/ALKMyGenericListCell.swift
@@ -218,7 +218,7 @@ class ALKMyGenericListCell: ALKChatBaseCell<ALKMessageViewModel> {
     
     private func updateMessageView(_ viewModel: ALKMessageViewModel) {
         messageView.text = viewModel.message ?? ""
-        messageView.setStyle(ALKMessageStyle.message)
+        messageView.setStyle(ALKMessageStyle.sentMessage)
         timeLabel.text = viewModel.time
         timeLabel.setStyle(ALKMessageStyle.time)
         

--- a/Sources/Views/ALKMyMessageView.swift
+++ b/Sources/Views/ALKMyMessageView.swift
@@ -81,7 +81,7 @@ class ALKMyMessageView: UIView {
     func update(viewModel: ALKMessageViewModel) {
         // Set message
         messageView.text = viewModel.message ?? ""
-        messageView.setStyle(ALKMessageStyle.message)
+        messageView.setStyle(ALKMessageStyle.sentMessage)
 
         // Set time
         timeLabel.text = viewModel.time
@@ -108,7 +108,7 @@ class ALKMyMessageView: UIView {
         guard let message = viewModel.message else {
             return minimumHeight
         }
-        let font = ALKMessageStyle.message.font
+        let font = ALKMessageStyle.sentMessage.font
         var messageHeight = message.heightWithConstrainedWidth(width: width, font: font)
         messageHeight += 20 // (6 + 4) + 10 for extra padding
         return max(messageHeight, minimumHeight)

--- a/Sources/Views/ALKMyPhotoPortalCell.swift
+++ b/Sources/Views/ALKMyPhotoPortalCell.swift
@@ -31,6 +31,10 @@ final class ALKMyPhotoPortalCell: ALKPhotoCell {
         }
     }
 
+    override class var messageTextFont: UIFont {
+        return ALKMessageStyle.sentMessage.font
+    }
+
     override func setupViews() {
         super.setupViews()
         
@@ -88,6 +92,8 @@ final class ALKMyPhotoPortalCell: ALKPhotoCell {
 
     override func setupStyle() {
         super.setupStyle()
+        captionLabel.font = ALKMessageStyle.sentMessage.font
+        captionLabel.textColor = ALKMessageStyle.sentMessage.text
         if(ALKMessageStyle.sentBubble.style == .edge){
             bubbleView.layer.cornerRadius = ALKMessageStyle.sentBubble.cornerRadius
             bubbleView.backgroundColor = ALKMessageStyle.sentBubble.color

--- a/Sources/Views/ALKPhotoCell.swift
+++ b/Sources/Views/ALKPhotoCell.swift
@@ -68,10 +68,14 @@ class ALKPhotoCell: ALKChatBaseCell<ALKMessageViewModel>,
     var captionLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
-        label.font = ALKMessageStyle.message.font
         return label
     }()
     static var maxWidth = UIScreen.main.bounds.width
+
+    // To be changed from the class that is subclassing `ALKPhotoCell`
+    class var messageTextFont: UIFont {
+        return Font.normal(size: 12).font()
+    }
 
     // This will be used to calculate the size of the photo view.
     static var heightPercentage: CGFloat = 0.5
@@ -114,13 +118,12 @@ class ALKPhotoCell: ALKChatBaseCell<ALKMessageViewModel>,
         width: CGFloat) -> CGFloat {
 
         var height: CGFloat
-        let font = ALKMessageStyle.message.font
 
         height = ceil(width*heightPercentage)
         if let message = viewModel.message, !message.isEmpty {
             height += message.rectWithConstrainedWidth(
                 width*widthPercentage,
-                font: font).height.rounded(.up) + Padding.CaptionLabel.bottom
+                font: messageTextFont).height.rounded(.up) + Padding.CaptionLabel.bottom
         }
 
         return topPadding()+height+bottomPadding()


### PR DESCRIPTION
- Added an option to set separate styles for received and sent messages.
- Deprecated `message` style as received and sent message styles have been added.
- Tested by setting a random style. Will add a snapshot test case for this.