### PR TITLE
Refresh chat details when chat is opened from notification 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ### Fixes
 - [AL-3302] Fix duplicate messages for open group.
+- Fixed an issue where conversation details weren't getting refreshed when chat was opened from tapping on notification.
 
 2.3.0
 ---

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -355,7 +355,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         } else {
             tableView.reloadData()
         }
-        self.setupNavigation()
         contentOffsetDictionary = Dictionary<NSObject,AnyObject>()
         subscribeChannelToMqtt()
         print("id: ", viewModel.messageModels.first?.contactId as Any)
@@ -417,14 +416,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         replyMessageView.closeButtonTapped = {[weak self] _ in
             self?.hideReplyMessageView()
         }
-        //Check for group left
-        isChannelLeft()
-
-        guard viewModel.isContextBasedChat else {
-            toggleVisibilityOfContextTitleView(false)
-            return
-        }
-        prepareContextView()
     }
 
     func isChannelLeft() {
@@ -443,6 +434,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
 
     func prepareContextView(){
+        guard viewModel.isContextBasedChat else {
+            toggleVisibilityOfContextTitleView(false)
+            return
+        }
         guard let topicDetail = viewModel.getContextTitleData() else {return }
         contextTitleView.configureWith(value: topicDetail)
         toggleVisibilityOfContextTitleView(true)
@@ -593,13 +588,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         }
     }
 
-    private func prepareChatBar() {
-        // Update ChatBar's top view which contains send button and the text view.
-        chatBar.grayView.backgroundColor = configuration.backgroundColor
-
-        // Update background view's color which contains all the attachment options.
-        chatBar.bottomGrayView.backgroundColor = configuration.chatBarAttachmentViewBackgroundColor
-
+    private func configureChatBar() {
         if viewModel.isOpenGroup {
             hideMediaOptions()
             chatBar.hideMicButton()
@@ -607,6 +596,14 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             if configuration.hideAllOptionsInChatBar {hideMediaOptions()}
             else {showMediaOptions()}
         }
+    }
+
+    private func prepareChatBar() {
+        // Update ChatBar's top view which contains send button and the text view.
+        chatBar.grayView.backgroundColor = configuration.backgroundColor
+
+        // Update background view's color which contains all the attachment options.
+        chatBar.bottomGrayView.backgroundColor = configuration.chatBarAttachmentViewBackgroundColor
 
         chatBar.poweredByMessageLabel.attributedText =
             NSAttributedString(string: "Powered by Applozic")
@@ -743,6 +740,13 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     public func refreshViewController() {
         viewModel.clearViewModel()
         tableView.reloadData()
+
+        setupNavigation()
+        prepareContextView()
+        configureChatBar()
+        //Check for group left
+        isChannelLeft()
+
         viewModel.prepareController()
     }
 

--- a/Sources/Views/ALKConversationNavBar.swift
+++ b/Sources/Views/ALKConversationNavBar.swift
@@ -101,10 +101,10 @@ class ALKConversationNavBar: UIView, Localizable {
         profileView.isHidden = false
         setupProfile(name: profile.name, imageUrl: profile.imageUrl, isContact: (profile.status != nil))
         guard let status = profile.status else {
-            statusIconBackground.isHidden = true
-            onlineStatusText.isHidden = true
+            self.hideStatus(true)
             return
         }
+        self.hideStatus(false)
         updateStatus(isOnline: status.isOnline, lastSeenAt: status.lastSeenAt)
     }
 
@@ -161,6 +161,11 @@ class ALKConversationNavBar: UIView, Localizable {
         profileView.topAnchor.constraint(equalTo: profileImage.topAnchor).isActive = true
         profileView.bottomAnchor.constraint(equalTo: profileImage.bottomAnchor).isActive = true
         profileView.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+    }
+
+    private func hideStatus(_ hide: Bool) {
+        statusIconBackground.isHidden = hide
+        onlineStatusText.isHidden = hide
     }
 
     private func setupStyle() {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
It will fix an issue where chat details like :: user details on navigation bar, hide/show chat bar etc when conversation is opened from tapping on notification.

## Motivation
<!-- Why are you making this change? -->
Conversation View wasn't being refreshed correctly.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested on simulator as well as device.