### PR TITLE
[AL-3307] Fix issue where typing comes when user types in other chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ### Fixes
 - [AL-3302] Fix duplicate messages for open group.
 - Fixed an issue where conversation details weren't getting refreshed when chat was opened from tapping on notification.
+- [AL-3307] Fixed an issue where typing indicator in 1-1 chat when user was typing in group.
 
 2.3.0
 ---

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -280,6 +280,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
     fileprivate func push(conversationVC: ALKConversationViewController, with viewModel: ALKConversationViewModel) {
         if let topVC = navigationController?.topViewController as? ALKConversationViewController {
             // Update the details and refresh
+            topVC.unsubscribingChannel()
             topVC.viewModel.contactId = viewModel.contactId
             topVC.viewModel.channelKey = viewModel.channelKey
             topVC.viewModel.conversationProxy = viewModel.conversationProxy


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
It will fix an issue where typing indicator was coming inside 1-1chat when user was typing in group chat. 

## Motivation
<!-- Why are you making this change? -->
Inconsistent typing indicator behavior

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested on simulator. Need testing on device.