### PR TITLE
[AL-3301] Add a way to use custom views for in-app notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 2.5.0(Upcoming release)
 ---
-
 ### Enhancements
-
--[AL-3280]Added support for profanity filter. To enable this feature set the filename of the profane words list in the configuration.
+- [AL-3301] Added a way to use custom view for in-app notifications.
+- [AL-3280] Added support for profanity filter. To enable this feature set the filename of the profane words list in the configuration.
 
 2.4.0
 ---

--- a/Demo/ApplozicSwiftDemo.xcodeproj/project.pbxproj
+++ b/Demo/ApplozicSwiftDemo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1A2E788721726E7200CF35AE /* ALKConversationListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E788621726E7200CF35AE /* ALKConversationListViewControllerTests.swift */; };
 		1A3D93F8213D29AC00BEC565 /* ApplozicSwiftAudioRecordingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3D93F7213D29AC00BEC565 /* ApplozicSwiftAudioRecordingUITests.swift */; };
 		1A5503FE22366BD700F642A9 /* MockMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5503FD22366BD700F642A9 /* MockMessage.swift */; };
+		1A661EDE2241146600093559 /* PushNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A661EDD2241146600093559 /* PushNotificationHandler.swift */; };
 		1A6D3A542180C9A300BB7538 /* ALKConversationViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6D3A532180C9A300BB7538 /* ALKConversationViewControllerTests.swift */; };
 		1A6D3A562180CB4500BB7538 /* ALContactServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6D3A552180CB4500BB7538 /* ALContactServiceMock.swift */; };
 		1A7129A821E71FD5007A7B78 /* ALKCurvedButtonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7129A721E71FD5007A7B78 /* ALKCurvedButtonSnapshotTests.swift */; };
@@ -97,6 +98,7 @@
 		1A2E788621726E7200CF35AE /* ALKConversationListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKConversationListViewControllerTests.swift; sourceTree = "<group>"; };
 		1A3D93F7213D29AC00BEC565 /* ApplozicSwiftAudioRecordingUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplozicSwiftAudioRecordingUITests.swift; sourceTree = "<group>"; };
 		1A5503FD22366BD700F642A9 /* MockMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMessage.swift; sourceTree = "<group>"; };
+		1A661EDD2241146600093559 /* PushNotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationHandler.swift; sourceTree = "<group>"; };
 		1A6D3A532180C9A300BB7538 /* ALKConversationViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ALKConversationViewControllerTests.swift; sourceTree = "<group>"; };
 		1A6D3A552180CB4500BB7538 /* ALContactServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALContactServiceMock.swift; sourceTree = "<group>"; };
 		1A7129A521E61296007A7B78 /* CurvedButton.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = CurvedButton.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -239,6 +241,7 @@
 				8B36D0EE1F3DC5E900FEFFD2 /* Assets.xcassets */,
 				8B36D0F01F3DC5E900FEFFD2 /* LaunchScreen.storyboard */,
 				8B36D0F31F3DC5E900FEFFD2 /* Info.plist */,
+				1A661EDD2241146600093559 /* PushNotificationHandler.swift */,
 			);
 			path = ApplozicSwiftDemo;
 			sourceTree = "<group>";
@@ -615,6 +618,7 @@
 				8BEF11AC1F618669000336AF /* ALChatManager.swift in Sources */,
 				8BEF11AE1F619367000336AF /* LoginViewController.swift in Sources */,
 				8B36D0EA1F3DC5E900FEFFD2 /* ViewController.swift in Sources */,
+				1A661EDE2241146600093559 /* PushNotificationHandler.swift in Sources */,
 				8B36D0E81F3DC5E900FEFFD2 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/ApplozicSwiftDemo.xcodeproj/project.pbxproj
+++ b/Demo/ApplozicSwiftDemo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		1A7129A821E71FD5007A7B78 /* ALKCurvedButtonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7129A721E71FD5007A7B78 /* ALKCurvedButtonSnapshotTests.swift */; };
 		1A7129AA21E72900007A7B78 /* ALKQuickReplyViewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7129A921E72900007A7B78 /* ALKQuickReplyViewSnapshotTests.swift */; };
 		1A933D7E21CA2E81004C5191 /* ConversationListTableVCMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A933D7D21CA2E81004C5191 /* ConversationListTableVCMock.swift */; };
+		1A96DD4222549DF600335C72 /* ContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A96DD4122549DF600335C72 /* ContainerViewController.swift */; };
 		1ACB680421806744000EB0E8 /* ALKConversationViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ACB680321806744000EB0E8 /* ALKConversationViewControllerSnapshotTests.swift */; };
 		1ACB6806218068AD000EB0E8 /* ALKChatBarSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ACB6805218068AD000EB0E8 /* ALKChatBarSnapshotTests.swift */; };
 		1ACD2A13217E5CB900B46BCC /* MuteConversationViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ACD2A12217E5CB900B46BCC /* MuteConversationViewControllerTests.swift */; };
@@ -106,6 +107,7 @@
 		1A7129A721E71FD5007A7B78 /* ALKCurvedButtonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKCurvedButtonSnapshotTests.swift; sourceTree = "<group>"; };
 		1A7129A921E72900007A7B78 /* ALKQuickReplyViewSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKQuickReplyViewSnapshotTests.swift; sourceTree = "<group>"; };
 		1A933D7D21CA2E81004C5191 /* ConversationListTableVCMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListTableVCMock.swift; sourceTree = "<group>"; };
+		1A96DD4122549DF600335C72 /* ContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerViewController.swift; sourceTree = "<group>"; };
 		1ACB680321806744000EB0E8 /* ALKConversationViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKConversationViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		1ACB6805218068AD000EB0E8 /* ALKChatBarSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKChatBarSnapshotTests.swift; sourceTree = "<group>"; };
 		1ACD2A12217E5CB900B46BCC /* MuteConversationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuteConversationViewControllerTests.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				8B36D0F01F3DC5E900FEFFD2 /* LaunchScreen.storyboard */,
 				8B36D0F31F3DC5E900FEFFD2 /* Info.plist */,
 				1A661EDD2241146600093559 /* PushNotificationHandler.swift */,
+				1A96DD4122549DF600335C72 /* ContainerViewController.swift */,
 			);
 			path = ApplozicSwiftDemo;
 			sourceTree = "<group>";
@@ -619,6 +622,7 @@
 				8BEF11AE1F619367000336AF /* LoginViewController.swift in Sources */,
 				8B36D0EA1F3DC5E900FEFFD2 /* ViewController.swift in Sources */,
 				1A661EDE2241146600093559 /* PushNotificationHandler.swift in Sources */,
+				1A96DD4222549DF600335C72 /* ContainerViewController.swift in Sources */,
 				8B36D0E81F3DC5E900FEFFD2 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/ApplozicSwiftDemo/AppDelegate.swift
+++ b/Demo/ApplozicSwiftDemo/AppDelegate.swift
@@ -28,10 +28,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         registerForNotification()
 
-        /// Use this for Customizing notification and comment ALKPushNotification.
-        /// - NOTE: Before using, remove ALApplozicSetting.setListOfViewController from ALChatManager.
+        /// Use this for Customizing notification
+        /// and comment ALKPushNotification line.
+        /// - NOTE:
+        ///      Before using, remove ALApplozicSetting.setListOfViewController from ALChatManager.
+        ///      In ViewController's launchChatList method uncomment the lines.
         /// PushNotificationHandler.shared.handleNotification(with: AppDelegate.config)
-    
         ALKPushNotificationHandler.shared.dataConnectionNotificationHandlerWith(AppDelegate.config)
         let alApplocalNotificationHnadler : ALAppLocalNotifications =  ALAppLocalNotifications.appLocalNotificationHandler()
         alApplocalNotificationHnadler.dataConnectionNotificationHandler()

--- a/Demo/ApplozicSwiftDemo/AppDelegate.swift
+++ b/Demo/ApplozicSwiftDemo/AppDelegate.swift
@@ -28,12 +28,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         registerForNotification()
 
-        /// Use this for Customizing notification
-        /// and comment ALKPushNotification line.
+        /// Use this for Customizing notification.
         /// - NOTE:
-        ///      Before using, remove ALApplozicSetting.setListOfViewController from ALChatManager.
-        ///      If you are trying in our sample, ViewController's launchChatList method uncomment the lines.
-        /// Uncomment this line
+        ///       Before using, comment ALKPushNotification line and remove
+        ///       ALApplozicSetting.setListOfViewController from ALChatManager.
+        ///       If you want to try this in our sample, then comment lines in ViewController's launchChatList method.
+        ///       Finally, Uncomment below line
         /// PushNotificationHandler.shared.handleNotification(with: AppDelegate.config)
         ALKPushNotificationHandler.shared.dataConnectionNotificationHandlerWith(AppDelegate.config)
         let alApplocalNotificationHnadler : ALAppLocalNotifications =  ALAppLocalNotifications.appLocalNotificationHandler()

--- a/Demo/ApplozicSwiftDemo/AppDelegate.swift
+++ b/Demo/ApplozicSwiftDemo/AppDelegate.swift
@@ -27,6 +27,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         BuddyBuildSDK.setup()
 
         registerForNotification()
+
+        /// Use this for Customizing notification and comment ALKPushNotification.
+        /// - NOTE: Before using, remove ALApplozicSetting.setListOfViewController from ALChatManager.
+        /// PushNotificationHandler.shared.handleNotification(with: AppDelegate.config)
     
         ALKPushNotificationHandler.shared.dataConnectionNotificationHandlerWith(AppDelegate.config)
         let alApplocalNotificationHnadler : ALAppLocalNotifications =  ALAppLocalNotifications.appLocalNotificationHandler()

--- a/Demo/ApplozicSwiftDemo/AppDelegate.swift
+++ b/Demo/ApplozicSwiftDemo/AppDelegate.swift
@@ -32,7 +32,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         /// and comment ALKPushNotification line.
         /// - NOTE:
         ///      Before using, remove ALApplozicSetting.setListOfViewController from ALChatManager.
-        ///      In ViewController's launchChatList method uncomment the lines.
+        ///      If you are trying in our sample, ViewController's launchChatList method uncomment the lines.
+        /// Uncomment this line
         /// PushNotificationHandler.shared.handleNotification(with: AppDelegate.config)
         ALKPushNotificationHandler.shared.dataConnectionNotificationHandlerWith(AppDelegate.config)
         let alApplocalNotificationHnadler : ALAppLocalNotifications =  ALAppLocalNotifications.appLocalNotificationHandler()

--- a/Demo/ApplozicSwiftDemo/ContainerViewController.swift
+++ b/Demo/ApplozicSwiftDemo/ContainerViewController.swift
@@ -1,0 +1,225 @@
+//
+//  ContainerViewController.swift
+//  ApplozicSwiftDemo
+//
+//  Created by Shivam Pokhriyal on 03/04/19.
+//  Copyright © 2019 Applozic. All rights reserved.
+//
+
+/// This is a sample to illustrate usage of custom in-app notifications.
+
+import UIKit
+import ApplozicSwift
+
+enum Menu: String {
+    case simple
+    case conversation
+    case profile
+}
+
+class ContainerViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.navigationController?.navigationBar.backgroundColor = UIColor.lightGray
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.pause, target: self, action: #selector(navigationItemTapped))
+        view.backgroundColor = .blue
+    }
+
+    @objc func navigationItemTapped() {
+        let menuController = MenuViewController()
+        let navVC = UINavigationController(rootViewController: menuController)
+        menuController.menuSelected = menuSelected(_:)
+        navVC.modalTransitionStyle = .flipHorizontal
+        navVC.modalPresentationStyle = .overCurrentContext
+        self.present(navVC, animated: true, completion: nil)
+    }
+
+    func menuSelected(_ menu: Menu) {
+        switch menu {
+        case .simple:
+            print("Simple")
+        case .conversation:
+            print("Conversation")
+            let vc = ConversationContainerViewController()
+            let navVC = UINavigationController(rootViewController: vc)
+            self.present(navVC, animated: true, completion: nil)
+        case .profile:
+            print("Profile")
+        }
+    }
+
+    func openConversationFromNotification(_ viewController: ALKConversationListViewController) {
+        let vc = ConversationContainerViewController()
+        vc.conversationVC = viewController
+        let navVC = UINavigationController(rootViewController: vc)
+        self.present(navVC, animated: true, completion: nil)
+    }
+
+}
+
+class ConversationContainerViewController: UIViewController {
+    lazy var conversationVC = ALKConversationListViewController(configuration: AppDelegate.config)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(back))
+        add(conversationVC)
+        conversationVC.view.frame = self.view.bounds
+        conversationVC.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        conversationVC.view.translatesAutoresizingMaskIntoConstraints = true
+    }
+
+    @objc func back() {
+        self.dismiss(animated: true, completion: nil)
+    }
+
+    deinit {
+        conversationVC.remove()
+    }
+}
+
+class MenuViewController: UIViewController {
+    let simpleButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(Menu.simple.rawValue, for: .normal)
+        return button
+    }()
+    let conversationButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(Menu.conversation.rawValue, for: .normal)
+        return button
+    }()
+    let profileButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(Menu.profile.rawValue, for: .normal)
+        return button
+    }()
+
+    let modalView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.lightGray
+        return view
+    }()
+
+    var menuSelected: ((Menu) -> Void)?
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.navigationController?.navigationBar.backgroundColor = UIColor.lightGray
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.done, target: self, action: #selector(backTapped))
+        setupConstraints()
+        setTarget()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setupConstraints() {
+        view.addViewsForAutolayout(views: [modalView])
+        modalView.addViewsForAutolayout(views: [simpleButton, conversationButton, profileButton])
+
+        modalView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.6).isActive = true
+        modalView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        modalView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        modalView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+
+        simpleButton.leadingAnchor.constraint(equalTo: modalView.leadingAnchor).isActive = true
+        simpleButton.trailingAnchor.constraint(equalTo: modalView.trailingAnchor).isActive = true
+        simpleButton.topAnchor.constraint(equalTo: modalView.topAnchor).isActive = true
+        simpleButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
+
+        conversationButton.leadingAnchor.constraint(equalTo: modalView.leadingAnchor).isActive = true
+        conversationButton.trailingAnchor.constraint(equalTo: modalView.trailingAnchor).isActive = true
+        conversationButton.topAnchor.constraint(equalTo: simpleButton.bottomAnchor, constant: 10).isActive = true
+        conversationButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
+
+        profileButton.leadingAnchor.constraint(equalTo: modalView.leadingAnchor).isActive = true
+        profileButton.trailingAnchor.constraint(equalTo: modalView.trailingAnchor).isActive = true
+        profileButton.topAnchor.constraint(equalTo: conversationButton.bottomAnchor, constant: 10).isActive = true
+        profileButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
+    }
+
+    @objc func buttonTapped(_ button: UIButton) {
+        guard
+            let title = button.title(for: .normal),
+            let menu = Menu(rawValue: title),
+            let menuSelected = menuSelected
+            else {
+                return
+        }
+        self.dismiss(animated: true) {
+            menuSelected(menu)
+        }
+    }
+
+    @objc func backTapped() {
+        self.dismiss(animated: true, completion: nil)
+    }
+
+    func setTarget() {
+        simpleButton.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+        conversationButton.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+        profileButton.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+    }
+}
+
+extension UIView {
+
+    func addViewsForAutolayout(views: [UIView]) {
+        for view in views {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(view)
+        }
+    }
+
+}
+
+extension UIViewController {
+
+    var bottomAnchor: NSLayoutYAxisAnchor {
+        if #available(iOS 11.0, *) {
+            return self.view.safeAreaLayoutGuide.bottomAnchor
+        } else {
+            return self.view.bottomAnchor
+        }
+    }
+
+    var topAnchor: NSLayoutYAxisAnchor {
+        if #available(iOS 11.0, *) {
+            return self.view.safeAreaLayoutGuide.topAnchor
+        } else {
+            return self.view.topAnchor
+        }
+    }
+
+    var leadingAnchor: NSLayoutXAxisAnchor {
+        if #available(iOS 11.0, *) {
+            return self.view.safeAreaLayoutGuide.leadingAnchor
+        } else {
+            return self.view.leadingAnchor
+        }
+    }
+
+    var trailingAnchor: NSLayoutXAxisAnchor {
+        if #available(iOS 11.0, *) {
+            return self.view.safeAreaLayoutGuide.trailingAnchor
+        } else {
+            return self.view.trailingAnchor
+        }
+    }
+
+    func add(_ child: UIViewController) {
+        addChild(child)
+        view.addSubview(child.view)
+        child.didMove(toParent: self)
+    }
+
+    func remove() {
+        guard parent != nil else { return }
+        willMove(toParent: nil)
+        view.removeFromSuperview()
+        removeFromParent()
+    }
+}

--- a/Demo/ApplozicSwiftDemo/ContainerViewController.swift
+++ b/Demo/ApplozicSwiftDemo/ContainerViewController.swift
@@ -41,19 +41,26 @@ class ContainerViewController: UIViewController {
             print("Simple")
         case .conversation:
             print("Conversation")
-            let vc = ConversationContainerViewController()
-            let navVC = UINavigationController(rootViewController: vc)
-            self.present(navVC, animated: true, completion: nil)
+            /// Use this to embed one more container.
+//            let vc = ConversationContainerViewController()
+//            let navVC = UINavigationController(rootViewController: vc)
+//            self.present(navVC, animated: true, completion: nil)
+            let conversationVC = ALKConversationListViewController(configuration: AppDelegate.config)
+            let nav = ALKBaseNavigationViewController(rootViewController: conversationVC)
+            self.present(nav, animated: false, completion: nil)
         case .profile:
             print("Profile")
         }
     }
 
     func openConversationFromNotification(_ viewController: ALKConversationListViewController) {
-        let vc = ConversationContainerViewController()
-        vc.conversationVC = viewController
-        let navVC = UINavigationController(rootViewController: vc)
-        self.present(navVC, animated: true, completion: nil)
+        /// Use this if you'd used `ConversationContainerViewController` above.
+//        let vc = ConversationContainerViewController()
+//        vc.conversationVC = viewController
+//        let navVC = UINavigationController(rootViewController: vc)
+//        self.present(navVC, animated: true, completion: nil)
+        let nav = ALKBaseNavigationViewController(rootViewController: viewController)
+        self.present(nav, animated: false, completion: nil)
     }
 
 }

--- a/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
+++ b/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
@@ -111,8 +111,25 @@ class PushNotificationHandler {
             NotificationHelper().handleNotificationTap(notification)
         } else {
             print("Applozic Controller not on top. Launch chat using helper methods.")
-            let vc = NotificationHelper().getConversationVCToLaunch(notification: notification, configuration: configuration)
-            topVC.present(vc, animated: true, completion: nil)
+            /// Below code needs to be changed depending on how you are using SDK.
+            /// Currently it shows demonstration on how it can be used with container.
+            switch topVC {
+                case let vc as ConversationContainerViewController:
+                    NotificationHelper().openConversationFromListVC(vc.conversationVC, notification: notification)
+                case let vc as ContainerViewController:
+                    let listVC = NotificationHelper().getConversationVCToLaunch(notification: notification, configuration: AppDelegate.config)
+                    vc.openConversationFromNotification(listVC)
+                case let vc as MenuViewController:
+                    vc.dismiss(animated: true) {
+                        guard let top = pushAssistant.topViewController as? ContainerViewController else {
+                            return
+                        }
+                        let listVC = NotificationHelper().getConversationVCToLaunch(notification: notification, configuration: AppDelegate.config)
+                        top.openConversationFromNotification(listVC)
+                    }
+                default:
+                    print("Some other controller Handle yourself")
+            }
         }
     }
 

--- a/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
+++ b/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
@@ -1,0 +1,119 @@
+//
+//  PushNotificationHandler.swift
+//  ApplozicSwiftDemo
+//
+//  Created by Shivam Pokhriyal on 19/03/19.
+//  Copyright © 2019 Applozic. All rights reserved.
+//
+
+import Foundation
+import Applozic
+import ApplozicSwift
+
+class PushNotificationHandler {
+    public static let shared = PushNotificationHandler()
+    var navVC: UINavigationController?
+
+    var contactId: String?
+    var groupId: NSNumber?
+    var conversationId: NSNumber?
+    var configuration: ALKConfiguration!
+
+    private var alContact: ALContact? {
+        let alContactDbService = ALContactDBService()
+        guard let alContact = alContactDbService.loadContact(byKey: "userId", value: self.contactId) else {
+            return nil
+        }
+        return alContact
+    }
+
+    private var alChannel: ALChannel? {
+        let alChannelService = ALChannelService()
+        guard let alChannel = alChannelService.getChannelByKey(self.groupId) else {
+            return nil
+        }
+        return alChannel
+    }
+
+    public func handleNotification(with configuration: ALKConfiguration) {
+        self.configuration = configuration
+
+        // No need to add removeObserver() as it is present in pushAssist.
+        NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "showNotificationAndLaunchChat"), object: nil, queue: nil, using: {[weak self] notification in
+            print("launch chat push notification received")
+            self?.contactId = nil
+            self?.groupId = nil
+            self?.conversationId = nil
+            //Todo: Handle group
+
+            guard let weakSelf = self, let object = notification.object as? String else { return }
+            let components = object.components(separatedBy: ":")
+
+            if components.count > 2 {
+                guard let componentElement = Int(components[1]) else { return }
+                weakSelf.groupId = NSNumber(integerLiteral: componentElement)
+            } else if components.count == 2 {
+                guard let conversationComponent = Int(components[1]) else { return }
+                weakSelf.conversationId = NSNumber(integerLiteral: conversationComponent)
+                weakSelf.contactId = components[0]
+            } else {
+                weakSelf.contactId = object
+            }
+
+            /// If app is active then show notification and handle click.
+            /// If app is inactive, then iOS notification will be shown, you only need to handle click.
+            if UIApplication.shared.applicationState == .active {
+                guard let userInfo = notification.userInfo, let alertValue = userInfo["alertValue"] as? String else {
+                    return
+                }
+                if weakSelf.isNotificationForActiveThread() { return }
+                ALUtilityClass.thirdDisplayNotificationTS(alertValue, andForContactId: weakSelf.contactId, withGroupId: weakSelf.groupId, completionHandler: {
+                    _ in
+                    weakSelf.launchIndividualChatWith(userId: weakSelf.contactId, groupId: weakSelf.groupId)
+                })
+            } else {
+                weakSelf.launchIndividualChatWith(userId: weakSelf.contactId, groupId: weakSelf.groupId)
+            }
+
+        })
+    }
+
+    func isNotificationForActiveThread() -> Bool {
+        let notification = NotificationHelper.NotificationData(userId: self.contactId, groupId: self.groupId, conversationId: self.conversationId)
+        return NotificationHelper().isNotificationForActiveThread(notification)
+    }
+
+    func launchIndividualChatWith(userId: String?, groupId: NSNumber?) {
+        print("Called when user taps on notification.")
+       /* Handle following cases ::
+         /* 1. Detailed chat screen is at top.
+                and chat was happening for the user for whom notification came.
+                So, add chat message to chat list.
+         */
+         /* 2. Detailed chat screen is at top.
+                and chat was happening with different user/group.
+                Here, refresh chat screen to show chat with the user for whom notification came.
+         */
+         /* 3. Chat list screen is at top.
+                open detailed chat with the user/group.
+         */
+         /* 4. Any other screen is at top.
+                push chat list screen and then push detailed chat.
+                Or you can directly push chat list while setting contactId/groupId
+                and it will open detailed chat automatically.
+         */
+       */
+        let notification = NotificationHelper.NotificationData(userId: self.contactId, groupId: self.groupId, conversationId: self.conversationId)
+        let pushAssistant = ALPushAssist()
+        guard let topVC = pushAssistant.topViewController else { return }
+        
+        if NotificationHelper().isApplozicVCAtTop() {
+            NotificationHelper().handleNotificationTap(notification)
+        } else {
+            print("Applozic Controller not on top. Launch chat using helper methods.")
+            let vc = NotificationHelper().getConversationVCToLaunch(notification: notification, configuration: configuration)
+            topVC.present(vc, animated: true, completion: nil)
+        }
+    }
+
+}

--- a/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
+++ b/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
@@ -10,30 +10,28 @@ import Foundation
 import Applozic
 import ApplozicSwift
 
+/* Handle following cases for notification ::
+     /* 1. Detailed chat screen is at top.
+         and chat was happening for the user for whom notification came.
+         So, Don't show notification.
+     */
+     /* 2. Detailed chat screen is at top.
+         and chat was happening with different user/group.
+         Here, refresh chat screen to show chat with the user for whom notification came.
+     */
+     /* 3. Chat list screen is at top.
+        open detailed chat with the user/group.
+     */
+     /* 4. Any other screen is at top.
+         push chat list screen and then push detailed chat.
+         Or you can directly push chat list while setting contactId/groupId
+         and it will open detailed chat automatically.
+     */
+ */
+
 class PushNotificationHandler {
     public static let shared = PushNotificationHandler()
-    var navVC: UINavigationController?
-
-    var contactId: String?
-    var groupId: NSNumber?
-    var conversationId: NSNumber?
     var configuration: ALKConfiguration!
-
-    private var alContact: ALContact? {
-        let alContactDbService = ALContactDBService()
-        guard let alContact = alContactDbService.loadContact(byKey: "userId", value: self.contactId) else {
-            return nil
-        }
-        return alContact
-    }
-
-    private var alChannel: ALChannel? {
-        let alChannelService = ALChannelService()
-        guard let alChannel = alChannelService.getChannelByKey(self.groupId) else {
-            return nil
-        }
-        return alChannel
-    }
 
     public func handleNotification(with configuration: ALKConfiguration) {
         self.configuration = configuration
@@ -41,94 +39,86 @@ class PushNotificationHandler {
         // No need to add removeObserver() as it is present in pushAssist.
         NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "showNotificationAndLaunchChat"), object: nil, queue: nil, using: {[weak self] notification in
             print("launch chat push notification received")
-            self?.contactId = nil
-            self?.groupId = nil
-            self?.conversationId = nil
-            //Todo: Handle group
+            let (notifData, msg) = NotificationHelper().notificationInfo(notification)
 
-            guard let weakSelf = self, let object = notification.object as? String else { return }
-            let components = object.components(separatedBy: ":")
-
-            if components.count > 2 {
-                guard let componentElement = Int(components[1]) else { return }
-                weakSelf.groupId = NSNumber(integerLiteral: componentElement)
-            } else if components.count == 2 {
-                guard let conversationComponent = Int(components[1]) else { return }
-                weakSelf.conversationId = NSNumber(integerLiteral: conversationComponent)
-                weakSelf.contactId = components[0]
-            } else {
-                weakSelf.contactId = object
-            }
+            guard
+                let weakSelf = self,
+                let notificationData = notifData,
+                let message = msg
+            else { return }
 
             /// If app is active then show notification and handle click.
             /// If app is inactive, then iOS notification will be shown, you only need to handle click.
             if UIApplication.shared.applicationState == .active {
-                guard let userInfo = notification.userInfo, let alertValue = userInfo["alertValue"] as? String else {
-                    return
-                }
-                if weakSelf.isNotificationForActiveThread() { return }
-                ALUtilityClass.thirdDisplayNotificationTS(alertValue, andForContactId: weakSelf.contactId, withGroupId: weakSelf.groupId, completionHandler: {
+                /// Before showing notification check if it is for active conversation.
+                /// - Note: This might not work if you added `ALKConversationViewController`
+                ///         inside container. If thats the case then handle accordingly.
+                guard !NotificationHelper().isNotificationForActiveThread(notificationData) else { return }
+                /// Here you can use any view to display notification.
+                /// Make sure on click of notification you call `launchIndividualChatWith` method
+                ALUtilityClass.thirdDisplayNotificationTS(
+                    message,
+                    andForContactId: notificationData.userId,
+                    withGroupId: notificationData.groupId,
+                    completionHandler: {
                     _ in
-                    weakSelf.launchIndividualChatWith(userId: weakSelf.contactId, groupId: weakSelf.groupId)
+                        weakSelf.launchIndividualChatWith(notificationData: notificationData)
                 })
             } else {
-                weakSelf.launchIndividualChatWith(userId: weakSelf.contactId, groupId: weakSelf.groupId)
+                weakSelf.launchIndividualChatWith(notificationData: notificationData)
             }
 
         })
     }
 
-    func isNotificationForActiveThread() -> Bool {
-        let notification = NotificationHelper.NotificationData(userId: self.contactId, groupId: self.groupId, conversationId: self.conversationId)
-        return NotificationHelper().isNotificationForActiveThread(notification)
-    }
-
-    func launchIndividualChatWith(userId: String?, groupId: NSNumber?) {
+    func launchIndividualChatWith(notificationData: NotificationHelper.NotificationData) {
         print("Called when user taps on notification.")
-       /* Handle following cases ::
-         /* 1. Detailed chat screen is at top.
-                and chat was happening for the user for whom notification came.
-                So, add chat message to chat list.
-         */
-         /* 2. Detailed chat screen is at top.
-                and chat was happening with different user/group.
-                Here, refresh chat screen to show chat with the user for whom notification came.
-         */
-         /* 3. Chat list screen is at top.
-                open detailed chat with the user/group.
-         */
-         /* 4. Any other screen is at top.
-                push chat list screen and then push detailed chat.
-                Or you can directly push chat list while setting contactId/groupId
-                and it will open detailed chat automatically.
-         */
-       */
-        let notification = NotificationHelper.NotificationData(userId: self.contactId, groupId: self.groupId, conversationId: self.conversationId)
-        let pushAssistant = ALPushAssist()
-        guard let topVC = pushAssistant.topViewController else { return }
-        
+
+        /// This will give false if our viewControllers are being added as child views.
         if NotificationHelper().isApplozicVCAtTop() {
-            NotificationHelper().handleNotificationTap(notification)
+            NotificationHelper().handleNotificationTap(notificationData)
         } else {
             print("Applozic Controller not on top. Launch chat using helper methods.")
+            let pushAssistant = ALPushAssist()
+            guard let topVC = pushAssistant.topViewController else { return }
             /// Below code needs to be changed depending on how you are using SDK.
-            /// Currently it shows demonstration on how it can be used with container.
+            /// Currently it shows how it can be used with container view controllers.
             switch topVC {
                 case let vc as ConversationContainerViewController:
-                    NotificationHelper().openConversationFromListVC(vc.conversationVC, notification: notification)
+                    /// This is the container view in which list is added.
+                    /// If this is at top, then pass the instance of list in this helper method
+                    /// and the helper will launch the detail chat.
+                    NotificationHelper().openConversationFromListVC(vc.conversationVC, notification: notificationData)
                 case let vc as ContainerViewController:
-                    let listVC = NotificationHelper().getConversationVCToLaunch(notification: notification, configuration: AppDelegate.config)
+                    /// This is the main container view for app.
+                    /// It indicated that chat view is not visible.
+                    /// Here call below helper method to get an instance of list VC which will open detail chat.
+                    let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: configuration)
+                    /// Navigate to the controller where list is added and use this instance there.
                     vc.openConversationFromNotification(listVC)
+
+                /// In below 2 cases some other view controller is opened.
+                /// Do same as above : Use helper method to get instance of listVC which will
+                /// open detail chat. And navigate to the controller where list is addded
+                /// In that controller use the instance returned by helper method.
                 case let vc as MenuViewController:
                     vc.dismiss(animated: true) {
                         guard let top = pushAssistant.topViewController as? ContainerViewController else {
                             return
                         }
-                        let listVC = NotificationHelper().getConversationVCToLaunch(notification: notification, configuration: AppDelegate.config)
+                        let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: AppDelegate.config)
                         top.openConversationFromNotification(listVC)
                     }
+                case let vc as ViewController:
+                    let container = ContainerViewController()
+                    let nav = ALKBaseNavigationViewController(rootViewController: container)
+                    vc.present(nav, animated: true) {
+                        let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: self.configuration)
+                        /// Navigate to the controller where list is added and use this instance there.
+                        container.openConversationFromNotification(listVC)
+                    }
                 default:
-                    print("Some other controller Handle yourself")
+                    print("Some other controller Handle It!")
             }
         }
     }

--- a/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
+++ b/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
@@ -11,19 +11,19 @@ import Applozic
 import ApplozicSwift
 
 /* Handle following cases for notification ::
-     /* 1. Detailed chat screen is at top.
-         and chat was happening for the user for whom notification came.
+     /* 1. Detailed chat screen is on top.
+         And chat was happening for the user for whom notification came.
          So, Don't show notification.
      */
-     /* 2. Detailed chat screen is at top.
-         and chat was happening with different user/group.
+     /* 2. Detailed chat screen is on top.
+         And chat was happening with different user/group.
          Here, refresh chat screen to show chat with the user for whom notification came.
      */
-     /* 3. Chat list screen is at top.
-        open detailed chat with the user/group.
+     /* 3. Chat list screen is on top.
+         Open detailed chat with the user/group.
      */
-     /* 4. Any other screen is at top.
-         push chat list screen and then push detailed chat.
+     /* 4. Any other screen is on top.
+         Push chat list screen and then push detailed chat.
          Or you can directly push chat list while setting contactId/groupId
          and it will open detailed chat automatically.
      */
@@ -51,6 +51,8 @@ class PushNotificationHandler {
             /// If app is inactive, then iOS notification will be shown, you only need to handle click.
             if UIApplication.shared.applicationState == .active {
                 /// Before showing notification check if it is for active conversation.
+                /// You can also check if notification came for muted or blocked conversation
+                /// using NotificationData and show notification accordingly.
                 /// - Note: This might not work if you added `ALKConversationViewController`
                 ///         inside container. If thats the case then handle accordingly.
                 guard !NotificationHelper().isNotificationForActiveThread(notificationData) else { return }
@@ -96,13 +98,13 @@ class PushNotificationHandler {
                 NotificationHelper().openConversationFromListVC(vc.conversationVC, notification: notificationData)
             case let vc as ContainerViewController:
                 /// This is the main container view for app.
-                /// It indicated that chat view is not visible.
+                /// It indicates that chat view is not visible.
                 /// Here call below helper method to get an instance of list VC which will open detail chat.
                 let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: configuration)
                 /// Navigate to the controller where list is added and use this instance there.
                 vc.openConversationFromNotification(listVC)
 
-                /// In below 2 cases some other view controller is opened.
+                /// In below 2 cases some other view controller is open.
                 /// Do same as above : Use helper method to get instance of listVC which will
                 /// open detail chat. And navigate to the controller where list is addded
             /// In that controller use the instance returned by helper method.

--- a/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
+++ b/Demo/ApplozicSwiftDemo/PushNotificationHandler.swift
@@ -79,47 +79,51 @@ class PushNotificationHandler {
             NotificationHelper().handleNotificationTap(notificationData)
         } else {
             print("Applozic Controller not on top. Launch chat using helper methods.")
-            let pushAssistant = ALPushAssist()
-            guard let topVC = pushAssistant.topViewController else { return }
-            /// Below code needs to be changed depending on how you are using SDK.
-            /// Currently it shows how it can be used with container view controllers.
-            switch topVC {
-                case let vc as ConversationContainerViewController:
-                    /// This is the container view in which list is added.
-                    /// If this is at top, then pass the instance of list in this helper method
-                    /// and the helper will launch the detail chat.
-                    NotificationHelper().openConversationFromListVC(vc.conversationVC, notification: notificationData)
-                case let vc as ContainerViewController:
-                    /// This is the main container view for app.
-                    /// It indicated that chat view is not visible.
-                    /// Here call below helper method to get an instance of list VC which will open detail chat.
-                    let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: configuration)
-                    /// Navigate to the controller where list is added and use this instance there.
-                    vc.openConversationFromNotification(listVC)
+            handleNotificationWhenApplozicNotOnTop(notificationData)
+        }
+    }
+
+    private func handleNotificationWhenApplozicNotOnTop(_ notificationData: NotificationHelper.NotificationData) {
+        let pushAssistant = ALPushAssist()
+        guard let topVC = pushAssistant.topViewController else { return }
+        /// Below code needs to be changed depending on how you are using SDK.
+        /// Currently it shows how it can be used with container view controllers.
+        switch topVC {
+            case let vc as ConversationContainerViewController:
+                /// This is the container view in which list is added.
+                /// If this is at top, then pass the instance of list in this helper method
+                /// and the helper will launch the detail chat.
+                NotificationHelper().openConversationFromListVC(vc.conversationVC, notification: notificationData)
+            case let vc as ContainerViewController:
+                /// This is the main container view for app.
+                /// It indicated that chat view is not visible.
+                /// Here call below helper method to get an instance of list VC which will open detail chat.
+                let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: configuration)
+                /// Navigate to the controller where list is added and use this instance there.
+                vc.openConversationFromNotification(listVC)
 
                 /// In below 2 cases some other view controller is opened.
                 /// Do same as above : Use helper method to get instance of listVC which will
                 /// open detail chat. And navigate to the controller where list is addded
-                /// In that controller use the instance returned by helper method.
-                case let vc as MenuViewController:
-                    vc.dismiss(animated: true) {
-                        guard let top = pushAssistant.topViewController as? ContainerViewController else {
-                            return
-                        }
-                        let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: AppDelegate.config)
-                        top.openConversationFromNotification(listVC)
+            /// In that controller use the instance returned by helper method.
+            case let vc as MenuViewController:
+                vc.dismiss(animated: true) {
+                    guard let top = pushAssistant.topViewController as? ContainerViewController else {
+                        return
                     }
-                case let vc as ViewController:
-                    let container = ContainerViewController()
-                    let nav = ALKBaseNavigationViewController(rootViewController: container)
-                    vc.present(nav, animated: true) {
-                        let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: self.configuration)
-                        /// Navigate to the controller where list is added and use this instance there.
-                        container.openConversationFromNotification(listVC)
-                    }
-                default:
-                    print("Some other controller Handle It!")
-            }
+                    let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: AppDelegate.config)
+                    top.openConversationFromNotification(listVC)
+                }
+            case let vc as ViewController:
+                let container = ContainerViewController()
+                let nav = ALKBaseNavigationViewController(rootViewController: container)
+                vc.present(nav, animated: true) {
+                    let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: self.configuration)
+                    /// Navigate to the controller where list is added and use this instance there.
+                    container.openConversationFromNotification(listVC)
+                }
+            default:
+                print("Some other controller Handle It!")
         }
     }
 

--- a/Demo/ApplozicSwiftDemo/ViewController.swift
+++ b/Demo/ApplozicSwiftDemo/ViewController.swift
@@ -38,5 +38,9 @@ class ViewController: UIViewController {
         let conversationVC = ALKConversationListViewController(configuration: AppDelegate.config)
         let nav = ALKBaseNavigationViewController(rootViewController: conversationVC)
         self.present(nav, animated: false, completion: nil)
+//        Use this to check sample for custom push notif. Comment above lines.
+//        let vc = ContainerViewController()
+//        let nav = ALKBaseNavigationViewController(rootViewController: vc)
+//        self.present(nav, animated: false, completion: nil)
     }
 }

--- a/Sources/Utilities/NotificationHelper.swift
+++ b/Sources/Utilities/NotificationHelper.swift
@@ -152,10 +152,11 @@ public class NotificationHelper {
             return
         }
         if vc.navigationController != nil {
-            //TODO: Find a better way to dismiss or pop.
-            vc.navigationController?.popViewController(animated: false)
-            vc.navigationController?.dismiss(animated: false) {
-                completion()
+            let isPopped = vc.navigationController?.popViewController(animated: false)
+            if isPopped == nil {
+                vc.dismiss(animated: false) {
+                    completion()
+                }
             }
         } else {
             completion()

--- a/Sources/Utilities/NotificationHelper.swift
+++ b/Sources/Utilities/NotificationHelper.swift
@@ -96,6 +96,7 @@ public class NotificationHelper {
     ///   - viewController: An instance of `ALKConversationViewController` which is at top.
     ///   - notification: notification that is tapped.
     public func refreshConversation(_ viewController: ALKConversationViewController, with notification: NotificationData) {
+        viewController.unsubscribingChannel()
         viewController.viewModel.contactId = notification.userId
         viewController.viewModel.channelKey = notification.groupId
         var convProxy: ALConversationProxy?
@@ -120,6 +121,8 @@ public class NotificationHelper {
             case "WebViewController":
                 fallthrough
             case "SelectProfilePicViewController":
+                fallthrough
+            case "CAMImagePickerCameraViewController": /// Cannot find any alternative.
                 fallthrough
             case _ where vc.hasPrefix("ALK"):
                 return true
@@ -177,7 +180,7 @@ public class NotificationHelper {
                 self.handleNotificationTap(notification)
             }
         } else {
-            vc.dismiss(animated: true) {
+            vc.dismiss(animated: false) {
                 self.findChatVC(notification)
             }
         }
@@ -195,6 +198,8 @@ public class NotificationHelper {
                 vc.dismiss(animated: false) {
                     completion()
                 }
+            } else {
+                completion()
             }
         } else {
             completion()

--- a/Sources/Utilities/NotificationHelper.swift
+++ b/Sources/Utilities/NotificationHelper.swift
@@ -1,0 +1,164 @@
+//
+//  NotificationHelper.swift
+//  ApplozicSwift
+//
+//  Created by Shivam Pokhriyal on 25/03/19.
+//
+
+import Applozic
+
+public class NotificationHelper {
+
+    /// Stores information about the notification that arrives
+    public struct NotificationData {
+        let userId: String?
+        let groupId: NSNumber?
+        let conversationId: NSNumber?
+        public init(userId: String?, groupId: NSNumber?, conversationId: NSNumber?) {
+            self.userId = userId
+            self.groupId = groupId
+            self.conversationId = conversationId
+        }
+    }
+
+    public init() { }
+
+    // MARK: - Public methods
+
+    /// Checks if the incoming notification is for currently opened chat.
+    ///
+    /// - NOTE: Use this information to decide whether to show/hide notification
+    /// - Parameters:
+    ///   - notification: notification that is tapped
+    /// - Returns: Bool value indicating whether notification is for active chat.
+    public func isNotificationForActiveThread(_ notification: NotificationData) -> Bool {
+        guard
+            let topVC = ALPushAssist().topViewController as? ALKConversationViewController,
+            let viewModel = topVC.viewModel
+        else {
+            return false
+        }
+        let isGroupMessage = notification.groupId != nil && notification.groupId == viewModel.channelKey
+        let isOneToOneMessage = notification.groupId == nil && viewModel.channelKey == nil && notification.userId == viewModel.contactId
+        if isGroupMessage || isOneToOneMessage {
+            return true
+        }
+        return false
+    }
+
+    /// Launches `ALKConversationViewController` from list.
+    ///
+    /// - NOTE: Use this when list is at the top.
+    /// - Parameters:
+    ///   - viewController: `ALKConversationListViewController` instance which is on top.
+    ///   - notification: notification that is tapped.
+    public func openConversationFromListVC(_ viewController: ALKConversationListViewController, notification: NotificationData) {
+        viewController.launchChat(contactId: notification.userId, groupId: notification.groupId, conversationId: notification.conversationId)
+    }
+
+    /// Returns an instance of list view controller which should be pushed from outside.
+    /// It will launch `ALKConversationViewController`.
+    ///
+    /// - NOTE: Use this to launch chat when some other screen is opened.
+    /// - Parameters:
+    ///   - notification: notification that is tapped.
+    ///   - configuration: `ALKConfiguration` object.
+    /// - Returns: An instance of `ALKConversationListViewController`
+    public func getConversationVCToLaunch(notification: NotificationData, configuration: ALKConfiguration) -> ALKConversationListViewController {
+        let viewController = ALKConversationListViewController(configuration: configuration)
+        viewController.contactId = notification.userId
+        viewController.conversationId = notification.conversationId
+        viewController.channelKey = notification.groupId
+        return viewController
+    }
+
+    /// Refrehses `ALKConversationViewController` for the arrived notification.
+    ///
+    /// - NOTE: Use this when `ALKConversationViewController` is at top
+    /// - Parameters:
+    ///   - viewController: An instance of `ALKConversationViewController` which is at top.
+    ///   - notification: notification that is tapped.
+    public func refreshConversation(_ viewController: ALKConversationViewController, with notification: NotificationData) {
+        viewController.viewModel.contactId = notification.userId
+        viewController.viewModel.channelKey = notification.groupId
+        var convProxy: ALConversationProxy?
+        if let convId = notification.conversationId, let conversationProxy = ALConversationService().getConversationByKey(convId) {
+            convProxy = conversationProxy
+        }
+        viewController.viewModel.conversationProxy = convProxy
+        viewController.viewWillLoadFromTappingOnNotification()
+        viewController.refreshViewController()
+    }
+
+    /// Checks whether Applozic ViewController is at top.
+    ///
+    /// - WARNING: Doesn't work if Applozic's Controller is added inside some container.
+    /// - Returns: Bool value indicating whether Applozic view is at top.
+    public func isApplozicVCAtTop() -> Bool {
+        guard let topVC = ALPushAssist().topViewController else { return false }
+        let vc = String(describing: topVC.classForCoder)
+        switch vc {
+            case "MuteConversationViewController":
+                fallthrough
+            case "WebViewController":
+                fallthrough
+            case "SelectProfilePicViewController":
+                fallthrough
+            case _ where vc.hasPrefix("ALK"):
+                return true
+            default:
+                return false
+        }
+    }
+
+    /// Handles notification tap when any of Applozic's VC is at top.
+    ///
+    /// - WARNING: Use this only when `isApplozicVCAtTop` returns true.
+    /// - Parameter notification: Contains details about arrived notification.
+    public func handleNotificationTap(_ notification: NotificationData) {
+        guard let topVC = ALPushAssist().topViewController else { return }
+        switch topVC {
+            case let vc as ALKConversationListViewController:
+                print("ConversationListViewController on top")
+                openConversationFromListVC(vc, notification: notification)
+            case let vc as ALKConversationViewController:
+                print("ConversationViewController on top")
+                refreshConversation(vc, with: notification)
+            default:
+                print("Some other view controller need to find chat vc")
+                findChatVC(notification)
+        }
+    }
+
+    // MARK:- Private helper methods
+
+    private func findChatVC(_ notification: NotificationData) {
+        guard let vc = ALPushAssist().topViewController else { return }
+        if let _ = vc.navigationController?.viewControllers {
+            findControllerInStack(vc) {
+                self.handleNotificationTap(notification)
+            }
+        } else {
+            vc.dismiss(animated: true) {
+                self.findChatVC(notification)
+            }
+        }
+    }
+
+    private func findControllerInStack(_ vc: UIViewController,
+                                       completion: @escaping () -> Void) {
+        guard !String(describing: vc.classForCoder).hasPrefix("ALKConversation") else {
+            completion()
+            return
+        }
+        if vc.navigationController != nil {
+            //TODO: Find a better way to dismiss or pop.
+            vc.navigationController?.popViewController(animated: false)
+            vc.navigationController?.dismiss(animated: false) {
+                completion()
+            }
+        } else {
+            completion()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
This PR will add a way to use in-app notifications from outside of SDK. An example of the same is also added in this PR only.

## Motivation
<!-- Why are you making this change? -->
It will allow developers to use a completely different view for in-app notifications and will also solve notification handling issues when our chat controller is added inside containers.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested on simulator. Need thorough testing on device.