### PR TITLE
[AL-3312] Fix receiver profile issue in video cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - [AL-3302] Fix duplicate messages for open group.
 - Fixed an issue where conversation details weren't getting refreshed when chat was opened from tapping on notification.
 - [AL-3307] Fixed an issue where typing indicator in 1-1 chat when user was typing in group.
+- [AL-3312] Fixed an issue where profile image of receiver wasn't visible for video cells.
+
 
 2.3.0
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - Fixed an issue where conversation details weren't getting refreshed when chat was opened from tapping on notification.
 - [AL-3307] Fixed an issue where typing indicator in 1-1 chat when user was typing in group.
 - [AL-3312] Fixed an issue where profile image of receiver wasn't visible for video cells.
+-  Fixed an issue where video weren't being send after recording from the SDK.
 
 
 2.3.0

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1601,11 +1601,11 @@ extension ALKConversationViewController: UIImagePickerControllerDelegate, UINavi
         picker.dismiss(animated: true, completion: nil)
     }
 
-    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
+    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
 
         // Video attachment
-        if let mediaType = info[UIImagePickerController.InfoKey.mediaType.rawValue] as? String, mediaType == "public.movie" {
-            guard let url = info[UIImagePickerController.InfoKey.mediaURL.rawValue] as? URL else { return }
+        if let mediaType = info[UIImagePickerController.InfoKey.mediaType] as? String, mediaType == "public.movie" {
+            guard let url = info[UIImagePickerController.InfoKey.mediaURL] as? URL else { return }
             print("video path is: ", url.path)
             viewModel.encodeVideo(videoURL: url, completion: {
                 path in

--- a/Sources/Views/ALKFriendVideoCell.swift
+++ b/Sources/Views/ALKFriendVideoCell.swift
@@ -82,8 +82,16 @@ class ALKFriendVideoCell: ALKVideoCell {
 
     override func update(viewModel: ALKMessageViewModel) {
         super.update(viewModel: viewModel)
-
         nameLabel.text = viewModel.displayName
+
+        let placeHolder = UIImage(named: "placeholder", in: Bundle.applozic, compatibleWith: nil)
+        guard let url = viewModel.avatarURL else {
+            self.avatarImageView.image = placeHolder
+            return
+        }
+        let resource = ImageResource(downloadURL: url, cacheKey: url.absoluteString)
+        self.avatarImageView.kf.setImage(with: resource, placeholder: placeHolder, options: nil, progressBlock: nil, completionHandler: nil)
+
     }
 
     @objc private func avatarTappedAction() {


### PR DESCRIPTION
This PR will fix an issue where receiver's profile was not coming in case of video cells.
Tested on simulator, working fine now.

It will also fix the issue where videos recorded from SDK weren't being sent. **The worst kind of bug.** Simply because the delegates were optional and we had an older version of method(I guess) whose signature was slightly different from delegate method(only one parameter) and it wasn't getting called ever.