### PR TITLE
Call user detail API whenever detail chat is opened #trivial

### DIFF
--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -134,8 +134,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
             print("update user detail")
             ALUserService.updateUserDetail(userId, withCompletion: {
                 userDetail in
-                guard let detail = userDetail else { return }
-                NotificationCenter.default.post(name: NSNotification.Name(rawValue: "USER_DETAIL_OTHER_VC"), object: detail)
+                guard let _ = userDetail else { return }
                 weakSelf.tableView?.reloadData()
             })
         })

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1580,19 +1580,7 @@ extension ALKConversationViewController: ALMQTTConversationDelegate {
     public func updateUserDetail(_ userId: String!) {
         guard let userId = userId else { return }
         print("update user detail")
-
-        ALUserService.updateUserDetail(userId, withCompletion: {
-            userDetail in
-            guard let detail = userDetail else { return }
-            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "USER_DETAIL_OTHER_VC"), object: detail)
-            guard
-                !self.viewModel.isGroup,
-                userId == self.viewModel.contactId,
-                let contact = ALContactService().loadContact(byKey: "userId", value: userId)
-            else { return }
-            let profile = self.viewModel.conversationProfileFrom(contact: contact, channel: nil, conversation: nil)
-            self.navigationBar.updateView(profile: profile)
-        })
+        viewModel.updateUserDetail(userId)
     }
 }
 

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -944,6 +944,19 @@ open class ALKConversationViewModel: NSObject, Localizable {
         return ALApplicationInfo().showPoweredByMessage()
     }
 
+    func updateUserDetail(_ userId: String) {
+        ALUserService.updateUserDetail(userId, withCompletion: {
+            userDetail in
+            guard let _ = userDetail else { return }
+            guard
+                !self.isGroup,
+                userId == self.contactId,
+                let contact = ALContactService().loadContact(byKey: "userId", value: userId)
+                else { return }
+            self.delegate?.updateDisplay(contact: contact, channel: nil)
+        })
+    }
+
     func currentConversationProfile(completion: @escaping (ALKConversationProfile?) -> ()) {
         if conversationId != nil {
             ALConversationService().fetchTopicDetails(conversationId) { (error, conversationProxy) in
@@ -970,6 +983,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
                     completion(nil)
                     return
                 }
+                self.updateUserDetail(contact.userId)
                 completion(self.conversationProfileFrom(contact: contact, channel: nil, conversation: nil))
             }
         }


### PR DESCRIPTION
This Pr will add a server call for updating user details whenever 1-1 chat is launched.
This is needed because user connected status is not syncing properly in device.