### PR TITLE
[AL-3380] Fix chat-bar UI issue when message comes in group #trivial

### DIFF
--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -425,6 +425,13 @@ extension ALKConversationListViewController: ALMQTTConversationDelegate {
 
     open func reloadData(forUserBlockNotification userId: String!, andBlockFlag flag: Bool) {
         print("reload data")
+        let userDetail = ALUserDetail()
+        userDetail.userId = userId
+        viewModel.updateStatusFor(userDetail: userDetail)
+        guard let viewController = self.navigationController?.visibleViewController as? ALKConversationViewController else {
+            return
+        }
+        viewController.checkUserBlock()
     }
 
     open func updateLastSeen(atStatus alUserDetail: ALUserDetail!) {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -420,7 +420,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     func checkUserBlock() {
         guard !viewModel.isGroup, let contactId = viewModel.contactId else { return }
         ALUserService().getUserDetail(contactId) { (contact) in
-            guard let contact = contact, contact.block else { return }
+            guard let contact = contact, contact.block else {
+                self.chatBar.enableChat()
+                return
+            }
             self.chatBar.disableChat(message: self.localizedString(forKey: "UnblockToEnableChat", withDefaultValue: SystemMessage.Information.UnblockToEnableChat, fileName: self.configuration.localizedStringFileName))
         }
     }
@@ -1600,6 +1603,7 @@ extension ALKConversationViewController: ALMQTTConversationDelegate {
 
     public func reloadData(forUserBlockNotification userId: String!, andBlockFlag flag: Bool) {
         print("reload data")
+        checkUserBlock()
     }
 
     public func updateUserDetail(_ userId: String!) {

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -531,9 +531,17 @@ open class ALKChatBar: UIView, Localizable {
     func disableChat(message: String) {
         toggleUserInteractionForViews(enabled: false)
         placeHolder.text = message
+        if !soundRec.isHidden {
+            cancelAudioRecording()
+        }
+        if textView.text != nil {
+            textView.text = ""
+            clearTextInTextView()
+        }
     }
 
     func enableChat() {
+        guard soundRec.isHidden else { return }
         toggleUserInteractionForViews(enabled: true)
         placeHolder.text = NSLocalizedString("ChatHere", value: SystemMessage.Information.ChatHere, comment: "")
     }


### PR DESCRIPTION
1. This PR will fix an issue which happens in group chat where a user while recording audio when receives a message, placeholder text gets displayed even though audio recording was still in progress. 

2. It also solves another issue where user while recording audio, when removed from group would still be able to send that audio message. After that it works fine.

3. It will solve one more issue where block/unblock wasn't updating chat UI in real-time when performed from other devices.