### PR TITLE
[AL-3478]Add TemplateDecoder for decoding templates from the metadata #trivial

### DIFF
--- a/Demo/ApplozicSwiftDemo.xcodeproj/project.pbxproj
+++ b/Demo/ApplozicSwiftDemo.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		8B4E9FFD215A39C5001FD5F3 /* ALKConversationViewControllerListSnapShotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1E967220D679EC00A4EB34 /* ALKConversationViewControllerListSnapShotTests.swift */; };
 		8B4E9FFF215BC804001FD5F3 /* ALKConversationViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4E9FFE215BC804001FD5F3 /* ALKConversationViewModelMock.swift */; };
 		8B523B432067E1DE001B5989 /* ALMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B523B422067E1DE001B5989 /* ALMessageTests.swift */; };
+		8B68A9B42276DFAB0021638A /* TemplateDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68A9B32276DFAB0021638A /* TemplateDecoderTests.swift */; };
 		8BA6FAE32089F18700BB1F6F /* ALKGenericListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA6FAE22089F18700BB1F6F /* ALKGenericListTests.swift */; };
 		8BA84180206A5A40004DD252 /* ALKGenericCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA8417F206A5A40004DD252 /* ALKGenericCardTests.swift */; };
 		8BB6ACA82068E982003C3B26 /* ALKConversationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB6ACA72068E982003C3B26 /* ALKConversationViewModelTests.swift */; };
@@ -141,6 +142,7 @@
 		8B4E9FFB215A31B2001FD5F3 /* ALMessageDBServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALMessageDBServiceMock.swift; sourceTree = "<group>"; };
 		8B4E9FFE215BC804001FD5F3 /* ALKConversationViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKConversationViewModelMock.swift; sourceTree = "<group>"; };
 		8B523B422067E1DE001B5989 /* ALMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALMessageTests.swift; sourceTree = "<group>"; };
+		8B68A9B32276DFAB0021638A /* TemplateDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateDecoderTests.swift; sourceTree = "<group>"; };
 		8BA6FAE22089F18700BB1F6F /* ALKGenericListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKGenericListTests.swift; sourceTree = "<group>"; };
 		8BA8417F206A5A40004DD252 /* ALKGenericCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKGenericCardTests.swift; sourceTree = "<group>"; };
 		8BB6ACA72068E982003C3B26 /* ALKConversationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKConversationViewModelTests.swift; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 				1A7129A721E71FD5007A7B78 /* ALKCurvedButtonSnapshotTests.swift */,
 				1A7129A921E72900007A7B78 /* ALKQuickReplyViewSnapshotTests.swift */,
 				8B06E486225E353B00B7FA64 /* ProfanityFilterTests.swift */,
+				8B68A9B32276DFAB0021638A /* TemplateDecoderTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -454,6 +457,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -660,6 +664,7 @@
 				8BDDEA6B21D9F2EE005B22E3 /* ALKConversationVCMemoryLeakTests.swift in Sources */,
 				1A0B17EF21819FF800B19187 /* ALKConversationViewControllerMock.swift in Sources */,
 				1A7129AA21E72900007A7B78 /* ALKQuickReplyViewSnapshotTests.swift in Sources */,
+				8B68A9B42276DFAB0021638A /* TemplateDecoderTests.swift in Sources */,
 				1A2E788721726E7200CF35AE /* ALKConversationListViewControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/ApplozicSwiftDemoTests/Tests/TemplateDecoderTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/TemplateDecoderTests.swift
@@ -1,0 +1,37 @@
+//
+//  TemplateDecoderTests.swift
+//  ApplozicSwiftDemoTests
+//
+//  Created by Mukesh on 29/04/19.
+//  Copyright © 2019 Applozic. All rights reserved.
+//
+
+import XCTest
+@testable import ApplozicSwift
+
+class TemplateDecoderTests: XCTestCase {
+
+    struct CustomType: Decodable {
+        let title: String
+    }
+
+    func testWhenPayloadIsNotPresent() {
+
+        XCTAssertThrowsError(try TemplateDecoder.decode(ListTemplate.self, from: ["":""])) { error in
+            guard let decodingError = error as? TemplateDecodingError else {
+                XCTFail("Threw the wrong type of error")
+                return
+            }
+            XCTAssert(decodingError == .payloadMissing)
+        }
+    }
+
+    func testWhenEmptyPayloadIsPresent() {
+        XCTAssertThrowsError(try TemplateDecoder.decode(ListTemplate.self, from: ["payload":""]))
+    }
+
+    func testWhenCorrectPayloadIsPresent() {
+        let customJson = ["payload":"{\"title\": \"Hello\"}"]
+        XCTAssertNoThrow(try TemplateDecoder.decode(CustomType.self, from: customJson))
+    }
+}

--- a/Sources/Models/ALKMessageModel.swift
+++ b/Sources/Models/ALKMessageModel.swift
@@ -112,14 +112,3 @@ extension ALKMessageViewModel {
         return quickReplyArray
     }
 }
-
-extension ALKMessageViewModel {
-    func listTemplateFromMetadata() -> ListTemplate? {
-        guard let metadata = self.metadata,
-            let payload = metadata["payload"] as? String
-            else {
-                return nil
-        }
-        return try? JSONDecoder().decode(ListTemplate.self, from: payload.data)
-    }
-}

--- a/Sources/Utilities/TemplateDecoder.swift
+++ b/Sources/Utilities/TemplateDecoder.swift
@@ -1,0 +1,34 @@
+//
+//  TemplateDecoder.swift
+//  ApplozicSwift
+//
+//  Created by Mukesh on 28/04/19.
+//
+
+import Foundation
+
+/// An error that occurs when decoding a template.
+enum TemplateDecodingError: Error {
+    case payloadMissing
+}
+
+/// A type that decodes a template(payload) from ALMessage's metadata.
+struct TemplateDecoder {
+    /// Decodes a Template from the metadata.
+    /// - parameter metadata: Metadata present in the `ALMessage` which contains the `payload`.
+    /// - throws: `TemplateDecodingError.payloadMissing` if the payload key is not present or if it doesn't contain a `String`.
+    /// - throws: An error if any value throws an error during decoding.
+    static func decode<T>(_ to: T.Type, from metadata: [String: Any]) throws -> T where T: Decodable {
+
+        guard let payload = metadata["payload"] as? String
+            else {
+                throw TemplateDecodingError.payloadMissing
+        }
+        do {
+            let template = try JSONDecoder().decode(to, from: payload.data)
+            return template
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/Views/ALKFriendGenericListCell.swift
+++ b/Sources/Views/ALKFriendGenericListCell.swift
@@ -109,11 +109,11 @@ class ALKFriendGenericListCell: ALKChatBaseCell<ALKMessageViewModel> {
 
     override func update(viewModel: ALKMessageViewModel) {
         messageView.update(viewModel: viewModel)
-        guard let metadata = viewModel.metadata, let payload = metadata["payload"] as? String else {
+        guard let metadata = viewModel.metadata else {
             return
         }
         do {
-            let cardTemplate = try JSONDecoder().decode([ALKGenericListTemplate].self, from: payload.data)
+            let cardTemplate = try TemplateDecoder.decode([ALKGenericListTemplate].self, from: metadata)
             guard let title = metadata["headerText"] as? String else {
                 return
             }

--- a/Sources/Views/ALKGenericCardCell.swift
+++ b/Sources/Views/ALKGenericCardCell.swift
@@ -35,13 +35,12 @@ open class ALKGenericCardCollectionView: ALKIndexedCollectionView {
     class func getCardTemplate(message: ALKMessageViewModel) -> [CardTemplate]? {
         guard
             let metadata = message.metadata,
-            let payload = metadata["payload"] as? String,
             let templateId = metadata["templateId"] as? String
-            else { return nil}
+            else { return nil }
         switch templateId {
             case ActionableMessageType.cardTemplate.rawValue:
                 do {
-                    let templates = try JSONDecoder().decode([CardTemplate].self, from: payload.data)
+                    let templates = try TemplateDecoder.decode([CardTemplate].self, from: metadata)
                     return templates
                 } catch(let error) {
                     print("\(error)")
@@ -49,7 +48,7 @@ open class ALKGenericCardCollectionView: ALKIndexedCollectionView {
                 }
             case ActionableMessageType.genericCard.rawValue:
                 do {
-                    let cards = try JSONDecoder().decode([ALKGenericCard].self, from: payload.data)
+                    let cards = try TemplateDecoder.decode([ALKGenericCard].self, from: metadata)
                     var templates = [CardTemplate]()
                     for card in cards {
                         templates.append(Util().cardTemplate(from: card))

--- a/Sources/Views/ALKListTemplateCell.swift
+++ b/Sources/Views/ALKListTemplateCell.swift
@@ -126,7 +126,8 @@ public class ALKListTemplateCell: ALKChatBaseCell<ALKMessageViewModel> {
     }
 
     public func update(viewModel: ALKMessageViewModel, maxWidth: CGFloat) {
-        guard let template = viewModel.listTemplateFromMetadata() else {
+        guard let metadata = viewModel.metadata,
+            let template = try? TemplateDecoder.decode(ListTemplate.self, from: metadata) else {
             listTemplateView.isHidden = true
             self.layoutIfNeeded()
             return
@@ -138,7 +139,8 @@ public class ALKListTemplateCell: ALKChatBaseCell<ALKMessageViewModel> {
     }
 
     public class func rowHeight(viewModel: ALKMessageViewModel, maxWidth: CGFloat) -> CGFloat {
-        guard let template = viewModel.listTemplateFromMetadata() else {
+        guard let metadata = viewModel.metadata,
+            let template = try? TemplateDecoder.decode(ListTemplate.self, from: metadata) else {
             return CGFloat(0)
         }
         return ListTemplateView.rowHeight(template: template)


### PR DESCRIPTION
Created a new `TemplateDecoder` type to decode templates instead of doing it manually and in multiple places.

When creating a template model from the metadata, currently we look for the payload in multiple classes, which all those classes are aware of the payload key. The second issue is there is no proper handling in case `payload` is not present in the metadata.

  I handle these two problems by creating a TemplateDecoder which will be responsible for decoding. It will decode to the given template type from the `ALMessage`’s metadata. Throws an error if the `payload` not present. 

Testing: Added unit test cases.