### PR TITLE
[AL-3486]Add a check for textView when keyboard shows up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Also see the [releases](https://github.com/AppLozic/ApplozicSwift/releases) on Github.
 
+2.5.1(Upcoming release)
+
+### Enhancments
+
+### Fixes
+- [AL-3486]Fixed an issue where in some cases view was in an incorrect state if the keyboard is visible.
+
 2.5.0
 ---
 ### Enhancements

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -162,30 +162,33 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: nil, using: { [weak self]
             notification in
             print("keyboard will show")
-            guard let weakSelf = self else {return}
 
-                if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            let keyboardFrameValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
+            guard
+                let weakSelf = self,
+                weakSelf.chatBar.isTextViewFirstResponder,
+                let keyboardSize = (keyboardFrameValue as? NSValue)?.cgRectValue else {
+                    return
+            }
 
-                weakSelf.keyboardSize = keyboardSize
+            weakSelf.keyboardSize = keyboardSize
 
-                let tableView = weakSelf.tableView
+            let tableView = weakSelf.tableView
 
-                var h = CGFloat(0)
-                h = keyboardSize.height-h
+            var h = CGFloat(0)
+            h = keyboardSize.height-h
 
-                let newH = -1*h
-                if weakSelf.bottomConstraint?.constant == newH {return}
+            let newH = -1*h
+            if weakSelf.bottomConstraint?.constant == newH {return}
 
-                weakSelf.bottomConstraint?.constant = newH
+            weakSelf.bottomConstraint?.constant = newH
 
-                weakSelf.view?.layoutIfNeeded()
+            weakSelf.view?.layoutIfNeeded()
 
-                if tableView.isCellVisible(section: weakSelf.viewModel.messageModels.count-1, row: 0) {
-                    tableView.scrollToBottomByOfset(animated: false)
-                } else if weakSelf.viewModel.messageModels.count > 1 {
-                    weakSelf.unreadScrollButton.isHidden = false
-                }
-
+            if tableView.isCellVisible(section: weakSelf.viewModel.messageModels.count-1, row: 0) {
+                tableView.scrollToBottomByOfset(animated: false)
+            } else if weakSelf.viewModel.messageModels.count > 1 {
+                weakSelf.unreadScrollButton.isHidden = false
             }
         })
 

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -198,6 +198,11 @@ open class ALKChatBar: UIView, Localizable {
         return button
     }()
 
+    /// Returns true if the textView is first responder.
+    open var isTextViewFirstResponder: Bool {
+        return textView.isFirstResponder
+    }
+
     private enum ConstraintIdentifier: String {
         case mediaBackgroudViewHeight = "mediaBackgroudViewHeight"
         case poweredByMessageHeight = "poweredByMessageHeight"


### PR DESCRIPTION
This will fix an issue where KeyboardWillShow notification observer gets called in `ALKConversationViewController` even though the user is typing somewhere else, for example, when sharing the URL to Slack or Notes app.

Now, if the chatBar's textView is not the first responder then we'll do nothing.

Tested using the 'Share Conversation URL'  feature in Agent app.