### PR TITLE
[AL-3490]Add support for Back button action in Conversation VC if presented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 2.5.1(Upcoming release)
 
 ### Enhancments
+- [AL-3490]Added support for Back button action in Conversation VC if the VC is presented not pushed.
 
 ### Fixes
 - [AL-3486]Fixed an issue where in some cases view was in an incorrect state if the keyboard is visible.

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -405,7 +405,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         print("back tapped")
         view.endEditing(true)
         self.viewModel.sendKeyboardDoneTyping()
-        _ = navigationController?.popToRootViewController(animated: true)
+        let popVC = navigationController?.popToRootViewController(animated: true)
+        if popVC == nil {
+            self.dismiss(animated: true, completion: nil)
+        }
     }
 
     override func showAccountSuspensionView() {


### PR DESCRIPTION
Added support for Back button action in Conversation VC if it was presented not pushed. Now it will dismiss the VC if it can't pop.

Tested in the sample app by changing the default launch button action to present a conversation VC.