### PR TITLE
[AL-3533] Fix crash while removing tableVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 2.6.1
 ---
 ### Fixes
-- Fixed an issue where scrolling in group detail screen would cause inconsistency in profile images of participants.
-- Fixed an issue where app was crashing while removing table viewcontroller.
+- [AL-3533] Fixed an issue where scrolling in group detail screen would cause inconsistency in profile images of participants.
+- [AL-3533] Fixed an issue where app was crashing while removing table viewcontroller.
+- [AL-3548] Fixed an issue where app was crashing after tapping on notification.
 
 2.6.0
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Also see the [releases](https://github.com/AppLozic/ApplozicSwift/releases) on Github.
 
+2.6.1
+---
+### Fixes
+- Fixed an issue where scrolling in group detail screen would cause inconsistency in profile images of participants.
+- Fixed an issue where app was crashing while removing table viewcontroller.
+
 2.6.0
 ---
 ### Enhancements

--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListViewControllerTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListViewControllerTests.swift
@@ -53,7 +53,6 @@ class ALKConversationListViewControllerTests: XCTestCase {
         conversationVC.viewModel = ALKConversationViewModelMock(contactId: nil, channelKey: 000, localizedStringFileName: ALKConfiguration().localizedStringFileName)
 
         // Pass all mocks
-        conversationListVC.viewModel = conversationListVM
         conversationListVC.delegate = conversation
         conversationListVC.dbService = ALMessageDBServiceMock()
         conversationListVC.conversationViewController = conversationVC
@@ -62,9 +61,7 @@ class ALKConversationListViewControllerTests: XCTestCase {
         conversationListVC.viewWillAppear(false)
         let firstIndex = IndexPath(row: 0, section: 0)
         XCTAssertNotNil(conversationListVC.tableView)
-        guard let tableView = conversationListVC.tableView else {
-            return
-        }
+        let tableView = conversationListVC.tableView
         tableView.delegate?.tableView?(tableView, didSelectRowAt: firstIndex)
         
         wait(for: [selectItemExpectation], timeout: 2)

--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationViewControllerListSnapShotTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationViewControllerListSnapShotTests.swift
@@ -45,9 +45,7 @@ class ALKConversationViewControllerListSnapShotTests: QuickSpec {
 
             it("Open chat thread") {
                 XCTAssertNotNil(conversationVC.tableView)
-                guard let tableView = conversationVC.tableView else {
-                    return
-                }
+                let tableView = conversationVC.tableView 
                 tableView.delegate?.tableView?(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
                 XCTAssertNotNil(conversationVC.navigationController?.view)
                 expect(conversationVC.navigationController).toEventually(haveValidSnapshot())

--- a/Demo/ApplozicSwiftDemoTests/Tests/ConversationListTableViewControllerTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ConversationListTableViewControllerTests.swift
@@ -22,7 +22,7 @@ class ConversationListTableViewControllerTests: XCTestCase {
     }
     
     func testMuteConversationCalledFromDelegate() {
-        let conversationListTableVCMock = ConversationListTableVCMock(viewModel: ALKConversationListViewModel(), dbService: ALMessageDBService(), configuration: ALKConfiguration(), delegate: ConversationListTableViewDelegateMock(), showSearch: false)
+        let conversationListTableVCMock = ConversationListTableVCMock(viewModel: ALKConversationListViewModel(), dbService: ALMessageDBService(), configuration: ALKConfiguration(), showSearch: false)
         
         let muteConversationVC = MuteConversationViewController(delegate: conversationListTableVCMock.self, conversation: MockMessage().message, atIndexPath: IndexPath(row: 0, section: 0), configuration: ALKConfiguration())
         

--- a/Sources/Controllers/ALKConversationListTableViewController.swift
+++ b/Sources/Controllers/ALKConversationListTableViewController.swift
@@ -40,7 +40,7 @@ public class ALKConversationListTableViewController: UITableViewController, Loca
     })
 
     //MARK: - PRIVATE PROPERTIES
-    fileprivate weak var delegate: ALKConversationListTableViewDelegate?
+    weak var delegate: ALKConversationListTableViewDelegate?
     fileprivate var configuration: ALKConfiguration
     fileprivate var showSearch: Bool
     fileprivate var localizedStringFileName: String
@@ -64,13 +64,15 @@ public class ALKConversationListTableViewController: UITableViewController, Loca
         - configuration: A configuration to be used by this controller to configure different settings.
         - delegate: A delegate used to receive callbacks when chat cell is tapped.
      */
-    public init(viewModel: ALKConversationListViewModelProtocol, dbService: ALMessageDBService, configuration: ALKConfiguration, delegate: ALKConversationListTableViewDelegate, showSearch: Bool) {
+    public init(viewModel: ALKConversationListViewModelProtocol,
+                dbService: ALMessageDBService,
+                configuration: ALKConfiguration,
+                showSearch: Bool) {
         self.viewModel = viewModel
         self.configuration = configuration
         self.showSearch = showSearch
         self.localizedStringFileName = configuration.localizedStringFileName
         self.dbService = dbService
-        self.delegate = delegate
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1377,7 +1377,10 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         }
         tableView.scrollToRow(at: indexPath, at: UITableView.ScrollPosition.bottom, animated: true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.tableView.scrollToRow(at: indexPath, at: UITableView.ScrollPosition.bottom, animated: true)
+            let sectionCount = self.tableView.numberOfSections
+            if indexPath.section <= sectionCount {
+                self.tableView.scrollToRow(at: indexPath, at: UITableView.ScrollPosition.bottom, animated: true)
+            }
         }
     }
 

--- a/Sources/Views/ALKGroupMemberCell.swift
+++ b/Sources/Views/ALKGroupMemberCell.swift
@@ -104,21 +104,21 @@ class ALKGroupMemberCell: UICollectionViewCell {
         self.model = model
         nameLabel.text = model.name
         adminLabel.isHidden = !model.isAdmin
+        adminLabel.text = model.adminText
 
-        if model.addCell {
+        guard !model.addCell else {
             let image = UIImage(named: "icon_add_people-1", in: Bundle.applozic, compatibleWith: nil)
             profile.image = image
+            return
         }
 
-        if let urlString = model.image, let url = URL(string: urlString) {
-            let placeHolder = UIImage(named: "contactPlaceholder", in: Bundle.applozic, compatibleWith: nil)
-            let resource = ImageResource(downloadURL: url, cacheKey:url.absoluteString)
-            profile.kf.setImage(with: resource, placeholder: placeHolder, options: nil, progressBlock: nil, completionHandler: nil)
+        let placeHolder = UIImage(named: "contactPlaceholder", in: Bundle.applozic, compatibleWith: nil)
+        guard let urlString = model.image, let url = URL(string: urlString) else {
+            profile.image = placeHolder
+            return
         }
-
-        if let text = model.adminText {
-            adminLabel.text = text
-        }
+        let resource = ImageResource(downloadURL: url, cacheKey:url.absoluteString)
+        profile.kf.setImage(with: resource, placeholder: placeHolder, options: nil, progressBlock: nil, completionHandler: nil)
     }
 
     class func rowHeight() -> CGFloat {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
This PR will do the following fixes: 
1. Profile images in group detail page were getting changed while scrolling. 
2. Scrolling tableview to bottom after a delay was causing crash.
3. Fix crash while removing tableview in deinit.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
Tested on device. 