### PR TITLE
[AL-3391]Add support for autosuggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 2.6.1
 ---
+
+### Enhancments
+- [AL-3391] Add support for autosuggestions.
+
 ### Fixes
 - [AL-3533] Fixed an issue where scrolling in group detail screen would cause inconsistency in profile images of participants.
 - [AL-3533] Fixed an issue where app was crashing while removing table viewcontroller.

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -378,6 +378,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     override open func viewDidLoad() {
         super.viewDidLoad()
         setupConstraints()
+        autocompletionView.contentInset = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 0)
+        chatBar.setup(autocompletionView, withPrefex: "/")
+
         guard !configuration.restrictedWordsFileName.isEmpty else {
             return
         }
@@ -628,8 +631,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     private func prepareMoreBar() {
 
-        autocompletionView.contentInset = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 0)
-        chatBar.setup(autocompletionView, withPrefex: "/")
         moreBar.bottomAnchor.constraint(equalTo: chatBar.topAnchor).isActive = true
         moreBar.isHidden = true
         moreBar.setHandleAction { [weak self] (actionType) in

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -32,6 +32,15 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     public lazy var chatBar = ALKChatBar(frame: CGRect.zero, configuration: self.configuration)
 
+    public let autocompletionView: UITableView = {
+        let tableview = UITableView(frame: CGRect.zero, style: .plain)
+        tableview.backgroundColor = .white
+        tableview.estimatedRowHeight = 50
+        tableview.rowHeight = UITableView.automaticDimension
+        tableview.separatorStyle = .none
+        return tableview
+    }()
+
     var contactService: ALContactService!
 
     lazy var loadingIndicator = ALKLoadingIndicator(frame: .zero, color: self.configuration.navigationBarTitleColor)
@@ -482,7 +491,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     private func setupConstraints() {
 
-        var allViews = [backgroundView, contextTitleView, tableView, moreBar, chatBar, typingNoticeView, unreadScrollButton, replyMessageView]
+        var allViews = [backgroundView, contextTitleView, tableView, autocompletionView, moreBar, chatBar, typingNoticeView, unreadScrollButton, replyMessageView]
         if let templateView = templateView {
             allViews.append(templateView)
         }
@@ -508,6 +517,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
         tableView.bottomAnchor.constraint(equalTo: (templateView != nil) ? templateView!.topAnchor:typingNoticeView.topAnchor).isActive = true
 
+        autocompletionView.bottomAnchor
+            .constraint(equalTo: typingNoticeView.topAnchor).isActive = true
+        autocompletionView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        autocompletionView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
 
         typingNoticeViewHeighConstaint = typingNoticeView.heightAnchor.constraint(equalToConstant: 0)
         typingNoticeViewHeighConstaint?.isActive = true
@@ -520,7 +533,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         chatBar.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
         bottomConstraint = chatBar.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         bottomConstraint?.isActive = true
-
 
         replyMessageView.leadingAnchor.constraint(
             equalTo: view.leadingAnchor).isActive = true
@@ -616,6 +628,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     private func prepareMoreBar() {
 
+        autocompletionView.contentInset = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 0)
+        chatBar.setup(autocompletionView, withPrefex: "/")
         moreBar.bottomAnchor.constraint(equalTo: chatBar.topAnchor).isActive = true
         moreBar.isHidden = true
         moreBar.setHandleAction { [weak self] (actionType) in

--- a/Sources/Views/ALKChatBar+AutoSuggestion.swift
+++ b/Sources/Views/ALKChatBar+AutoSuggestion.swift
@@ -34,7 +34,11 @@ extension ALKChatBar: UITableViewDataSource, UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let text = filteredAutocompletionItems[indexPath.row].content
-        textView.text = text
+
+        // If we replace the text here then it resizes the textview incorrectly.
+        // That's why first resetting the text and then inserting the item content.
+        textView.text = ""
+        textView.insertText(text)
         updateTextViewHeight(textView: textView, text: text)
         hideAutoCompletionView()
     }

--- a/Sources/Views/ALKChatBar+AutoSuggestion.swift
+++ b/Sources/Views/ALKChatBar+AutoSuggestion.swift
@@ -1,0 +1,61 @@
+//
+//  ALKChatBar+AutoSuggestion.swift
+//  ApplozicSwift
+//
+//  Created by Mukesh on 29/05/19.
+//
+
+import Foundation
+
+extension ALKChatBar: UITableViewDataSource, UITableViewDelegate {
+
+    public func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return filteredAutocompletionItems.count
+    }
+
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        var cell: UITableViewCell! =
+            tableView.dequeueReusableCell(withIdentifier: UITableViewCell.reuseIdentifier)
+        if cell == nil {
+            cell = UITableViewCell(style: .subtitle, reuseIdentifier: UITableViewCell.reuseIdentifier)
+        }
+
+        guard indexPath.row < filteredAutocompletionItems.count else { return cell }
+        let item = filteredAutocompletionItems[indexPath.row]
+        cell.detailTextLabel?.setTextColor(.gray)
+        cell.textLabel?.text = "/\(item.key)"
+        cell.detailTextLabel?.text = "\(item.content)"
+        return cell
+    }
+
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let text = filteredAutocompletionItems[indexPath.row].content
+        textView.text = text
+        updateTextViewHeight(textView: textView, text: text)
+        hideAutoCompletionView()
+    }
+}
+
+extension ALKChatBar {
+    func itemsContaining(_ text: String, in list: [AutoCompleteItem]) -> [AutoCompleteItem] {
+        return list.filter { $0.key.lowercased().contains(text) }
+    }
+
+    /// This will show items relevant to the text entered in quick reply view.
+    /// NOTE: Pass everything other than the prefix, caller should consume the prefix.
+    func updateAutocompletionFor(text: String) {
+        if text.isEmpty {
+            filteredAutocompletionItems = autoCompletionItems
+        } else {
+            filteredAutocompletionItems = itemsContaining(text, in: autoCompletionItems)
+        }
+        UIView.performWithoutAnimation {
+            autocompletionView.reloadData()
+        }
+        showAutoCompletionView()
+    }
+}

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -311,6 +311,7 @@ open class ALKChatBar: UIView, Localizable {
         textView.text = ""
         clearTextInTextView()
         toggleKeyboardType(textView: textView)
+        hideAutoCompletionView()
     }
 
     func hideMicButton() {

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -10,6 +10,16 @@ import Foundation
 import UIKit
 import Applozic
 
+public struct AutoCompleteItem {
+    var key: String
+    var content: String
+
+    public init(key: String, content: String) {
+        self.key = key
+        self.content = content
+    }
+}
+
 open class ALKChatBar: UIView, Localizable {
 
     var configuration: ALKConfiguration!
@@ -48,6 +58,8 @@ open class ALKChatBar: UIView, Localizable {
         label.font = UIFont.systemFont(ofSize: 14)
         return label
     }()
+
+    public var autocompletionView: UITableView!
 
     lazy open var soundRec: ALKAudioRecorderView = {
         let view = ALKAudioRecorderView(frame: CGRect.zero, configuration: self.configuration)
@@ -282,6 +294,15 @@ open class ALKChatBar: UIView, Localizable {
         }
     }
 
+    func setup(_ tableview: UITableView, withPrefex prefix: String) {
+        autocompletionView = tableview
+        autocompletionView.dataSource = self
+        autocompletionView.delegate = self
+        autoCompletionViewHeightConstraint = autocompletionView.heightAnchor.constraint(equalToConstant: 0)
+        autoCompletionViewHeightConstraint?.isActive = true
+        self.prefix = prefix
+    }
+
     func setComingSoonDelegate(delegate: UIView) {
         comingSoonDelegate = delegate
     }
@@ -337,6 +358,12 @@ open class ALKChatBar: UIView, Localizable {
 
     fileprivate var textViewTrailingWithSend: NSLayoutConstraint?
     fileprivate var textViewTrailingWithMic: NSLayoutConstraint?
+    fileprivate var autoCompletionViewHeightConstraint: NSLayoutConstraint?
+
+    public var autoCompletionItems = [AutoCompleteItem]()
+    var filteredAutocompletionItems = [AutoCompleteItem]()
+
+    public var prefix: String? = nil
 
     private func setupConstraints(
         maxLength: CGFloat = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)) {
@@ -352,6 +379,7 @@ open class ALKChatBar: UIView, Localizable {
 
         var buttonSpacing: CGFloat = 30
         if maxLength <= 568.0 { buttonSpacing = 20 } // For iPhone 5
+
         addViewsForAutolayout(views: [headerView, bottomGrayView, plusButton, photoButton, grayView,  textView, sendButton, micButton, lineImageView, videoButton, galleryButton,locationButton, contactButton, lineView, frameView, placeHolder,soundRec, poweredByMessageLabel])
 
         lineView.topAnchor.constraint(equalTo: headerView.bottomAnchor).isActive = true
@@ -399,7 +427,7 @@ open class ALKChatBar: UIView, Localizable {
         lineImageView.topAnchor.constraint(equalTo: textView.topAnchor, constant: 10).isActive = true
         lineImageView.bottomAnchor.constraint(equalTo: textView.bottomAnchor, constant: -10).isActive = true
 
-        
+
         sendButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10).isActive = true
         sendButton.widthAnchor.constraint(equalToConstant: 28).isActive = true
         sendButton.heightAnchor.constraint(equalToConstant: 28).isActive = true
@@ -554,23 +582,14 @@ open class ALKChatBar: UIView, Localizable {
         toggleUserInteractionForViews(enabled: true)
         placeHolder.text = NSLocalizedString("ChatHere", value: SystemMessage.Information.ChatHere, comment: "")
     }
-}
 
-extension ALKChatBar: UITextViewDelegate {
-
-    public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText string: String) -> Bool {
-        guard var text = textView.text as NSString? else {
-            return true
-        }
-
-        text = text.replacingCharacters(in: range, with: string) as NSString
-
+    func updateTextViewHeight(textView: UITextView, text: String) {
         let style = NSMutableParagraphStyle()
         style.lineSpacing = 4.0
         let font = textView.font ?? UIFont.font(.normal(size: 14.0))
         let attributes = [NSAttributedString.Key.paragraphStyle: style, NSAttributedString.Key.font: font]
         let tv = UITextView(frame: textView.frame)
-        tv.attributedText = NSAttributedString(string: text as String, attributes:attributes)
+        tv.attributedText = NSAttributedString(string: text, attributes:attributes)
 
         let fixedWidth = textView.frame.size.width
         let size = tv.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
@@ -585,7 +604,18 @@ extension ALKChatBar: UITextViewDelegate {
 
             textView.layoutIfNeeded()
         }
+    }
+}
 
+extension ALKChatBar: UITextViewDelegate {
+
+    public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText string: String) -> Bool {
+        guard var text = textView.text as NSString? else {
+            return true
+        }
+
+        text = text.replacingCharacters(in: range, with: string) as NSString
+        updateTextViewHeight(textView: textView, text: text as String)
         return true
     }
 
@@ -594,6 +624,11 @@ extension ALKChatBar: UITextViewDelegate {
         self.placeHolder.alpha = textView.text.isEmpty ? 1.0 : 0.0
 
         toggleButtonInChatBar(hide: textView.text.isEmpty)
+        if showAutosuggestionsForText(textView.text, withPrefix: prefix ?? "") {
+            updateAutocompletionFor(text: String(textView.text.dropFirst()))
+        } else {
+            hideAutoCompletionView()
+        }
         if let selectedTextRange = textView.selectedTextRange {
             let line = textView.caretRect(for: selectedTextRange.start)
             let overflow = line.origin.y + line.size.height  - ( textView.contentOffset.y + textView.bounds.size.height - textView.contentInset.bottom - textView.contentInset.top )
@@ -650,6 +685,24 @@ extension ALKChatBar: UITextViewDelegate {
         textView.inputView = nil
         textView.reloadInputViews()
     }
+
+    func showAutoCompletionView() {
+        let contentHeight = autocompletionView.contentSize.height
+
+        let bottomPadding: CGFloat = contentHeight > 0 ? 25:0
+        let maxheight: CGFloat = 200
+        autoCompletionViewHeightConstraint?.constant = contentHeight < maxheight ? contentHeight+bottomPadding : maxheight
+    }
+
+    func hideAutoCompletionView() {
+        autoCompletionViewHeightConstraint?.constant = 0
+    }
+
+    func showAutosuggestionsForText(_ text: String, withPrefix prefix: String) -> Bool {
+        guard !prefix.isEmpty, text.starts(with: prefix) else { return false }
+        if text.count > 1, text[1] == " " { return false }
+        return true
+    }
 }
 
 extension ALKChatBar: ALKAudioRecorderProtocol {
@@ -679,7 +732,6 @@ extension ALKChatBar: ALKAudioRecorderProtocol {
     public func moveButton(location: CGPoint) {
         soundRec.moveView(location: location)
     }
-
 }
 
 extension ALKChatBar: ALKAudioRecorderViewProtocol {


### PR DESCRIPTION
This will add support for showing autosuggestions. If text input contains a prefix and if that prefix is supported then the suggestions will be shown. And as user types, we'll update the suggestions by showing only those suggestions
whose key contains user-entered text.

Tested it in Agent app where we'll be using this feature and, it's working fine.