### PR TITLE
Disable group details for support and open group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - [AL-3533] Fixed an issue where scrolling in group detail screen would cause inconsistency in profile images of participants.
 - [AL-3533] Fixed an issue where app was crashing while removing table viewcontroller.
 - [AL-3548] Fixed an issue where app was crashing after tapping on notification.
+- Now, group title action will be disabled for support group(GroupType = 10) as well.
 
 2.6.0
 ---

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -466,13 +466,11 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         }
         if  channel.type != 6 && channel.type != 10 && !members.contains(ALUserDefaultsHandler.getUserId()) {
             chatBar.disableChat(message: localizedString(forKey: "NotPartOfGroup", withDefaultValue: SystemMessage.Information.NotPartOfGroup, fileName: configuration.localizedStringFileName))
-            //Disable click on toolbar
-            navigationBar.disableTitleAction = true
         } else {
             chatBar.enableChat()
-            //Enable Click on toolbar
-            navigationBar.disableTitleAction = false
         }
+        // Disable group details for support group, open group and when user is not a member.
+        navigationBar.disableTitleAction = channel.type == 10 || channel.type == 6 || !members.contains(ALUserDefaultsHandler.getUserId())
     }
 
     func prepareContextView(){


### PR DESCRIPTION
This PR will disable group title action for support group and open group. 
For normal group, unless the user is part of the group, title action will be disabled.