### PR TITLE
ConverssationService: remove unwrapped optional #trivial

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -850,7 +850,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     /// Call this before changing viewModel contents
     public func unsubscribingChannel() {
-        guard viewModel != nil else { return }
+        guard viewModel != nil, alMqttConversationService != nil else { return }
         if !viewModel.isOpenGroup {
             self.alMqttConversationService.sendTypingStatus(
                 ALUserDefaultsHandler.getApplicationKey(),


### PR DESCRIPTION
 #218 alMqttConversationService was an implicitly unwrapped optional so there might be a possibility of it being nil. 
This PR will add a guard to prevent such mishappenings. 