### PR TITLE
Use default applicationId consent

### DIFF
--- a/Demo/ApplozicSwiftDemo/ALChatManager.swift
+++ b/Demo/ApplozicSwiftDemo/ALChatManager.swift
@@ -31,6 +31,9 @@ class ALChatManager: NSObject {
 
     init(applicationKey: NSString) {
         super.init()
+        if(applicationKey.length == 0 ){
+            fatalError("Please pass your applicationId in the ALChatManager file.")
+        }
         ALUserDefaultsHandler.setApplicationKey(applicationKey as String)
         self.defaultChatViewSettings()
     }
@@ -89,7 +92,7 @@ class ALChatManager: NSObject {
 
     func getApplicationKey() -> NSString {
         let appKey = ALUserDefaultsHandler.getApplicationKey() as NSString?
-        let applicationKey = appKey
+        let applicationKey = (appKey != nil) ? appKey : ALChatManager.applicationId as NSString?
         return applicationKey!;
     }
 


### PR DESCRIPTION
## Summary
Add an exception in case if application id is not passed  and use the default consent from chat manager in case the defaults are cleared 

## Motivation

## Testing
