### PR TITLE
Change some APIs to public and open to support user-info-screen

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -43,6 +43,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         return tableview
     }()
 
+    open lazy var navigationBar = ALKConversationNavBar(configuration: self.configuration, delegate: self)
+
     var contactService: ALContactService!
 
     lazy var loadingIndicator = ALKLoadingIndicator(frame: .zero, color: self.configuration.navigationBarTitleColor)
@@ -72,8 +74,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     fileprivate lazy var typingNoticeView = TypingNotice(localizedStringFileName : configuration.localizedStringFileName)
     fileprivate var alMqttConversationService: ALMQTTConversationService!
     fileprivate let activityIndicator = UIActivityIndicatorView(style: UIActivityIndicatorView.Style.gray)
-
-    fileprivate lazy var navigationBar = ALKConversationNavBar(configuration: self.configuration, delegate: self)
 
     fileprivate var keyboardSize: CGRect?
 
@@ -469,7 +469,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         }
     }
 
-    func isChannelLeft() {
+    open func isChannelLeft() {
         guard let channelKey = viewModel.channelKey, let channel = ALChannelService().getChannelByKey(channelKey) else {
             return
         }
@@ -1883,11 +1883,11 @@ extension ALKConversationViewController: ALKCustomPickerDelegate {
 }
 
 extension ALKConversationViewController: NavigationBarCallbacks {
-    func backButtonTapped() {
+    open func backButtonTapped() {
         backTapped()
     }
 
-    func titleTapped() {
+    open func titleTapped() {
         if let contact = contactDetails(), let contactId = contact.userId {
             let info: [String: Any] =
                 ["Id": contactId,

--- a/Sources/Utilities/ALKActivityIndicator.swift
+++ b/Sources/Utilities/ALKActivityIndicator.swift
@@ -7,18 +7,33 @@
 
 import UIKit
 
-class ALKActivityIndicator: UIView {
+/// Custom ActivityIndicator view which will present a white large styled UIActivityIndicator
+/// on top a rectangular background.
+public class ALKActivityIndicator: UIView {
 
-    struct Size {
-        let width: CGFloat
-        let height: CGFloat
+    public struct Size {
+        public let width: CGFloat
+        public let height: CGFloat
+        public init(width: CGFloat, height: CGFloat) {
+            self.width = width
+            self.height = height
+        }
     }
 
     let size: Size
 
     fileprivate var indicator = UIActivityIndicatorView(style: .whiteLarge)
 
-    init(frame: CGRect, backgroundColor: UIColor, indicatorColor: UIColor, size: Size) {
+    /// Initializers
+    ///
+    /// - Parameters:
+    ///   - frame: Used to set view's frame.
+    ///   - backgroundColor: Color of rectangular background.
+    ///   - indicatorColor: Color of ActivityIndicator.
+    ///   - size: Size of activity indicator.
+    ///
+    /// - Note: Make sure you use the same size passed here to set constraints to this view.
+    public init(frame: CGRect, backgroundColor: UIColor, indicatorColor: UIColor, size: Size) {
         self.size = size
         super.init(frame: frame)
         self.backgroundColor = backgroundColor
@@ -31,12 +46,12 @@ class ALKActivityIndicator: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func startAnimating() {
+    public func startAnimating() {
         self.isHidden = false
         indicator.startAnimating()
     }
 
-    func stopAnimating() {
+    public func stopAnimating() {
         self.isHidden = true
         indicator.stopAnimating()
     }

--- a/Sources/Views/ALKConversationNavBar.swift
+++ b/Sources/Views/ALKConversationNavBar.swift
@@ -8,17 +8,17 @@
 import Foundation
 import Kingfisher
 
-protocol NavigationBarCallbacks: class {
+@objc public protocol NavigationBarCallbacks: class {
     func backButtonTapped()
-    func titleTapped()
+    @objc func titleTapped()
 }
 
-class ALKConversationNavBar: UIView, Localizable {
+open class ALKConversationNavBar: UIView, Localizable {
 
     let navigationBarBackgroundColor: UIColor
     let configuration: ALKConfiguration
     weak var delegate: NavigationBarCallbacks?
-    var disableTitleAction: Bool = false
+    open var disableTitleAction: Bool = false
 
     let backButton: UIButton = {
         let view = UIButton()
@@ -83,7 +83,7 @@ class ALKConversationNavBar: UIView, Localizable {
         return stackView
     }()
 
-    required init(configuration: ALKConfiguration, delegate: NavigationBarCallbacks) {
+    required public init(configuration: ALKConfiguration, delegate: NavigationBarCallbacks) {
         self.navigationBarBackgroundColor = configuration.navigationBarBackgroundColor
         self.configuration = configuration
         self.delegate = delegate
@@ -93,7 +93,7 @@ class ALKConversationNavBar: UIView, Localizable {
         setupActions()
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
@@ -234,3 +234,4 @@ class ALKConversationNavBar: UIView, Localizable {
     }
 
 }
+


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
This PR will make ALKActivityIndicator public to be used outside and add docs for the usage.
It will make navigation bar of ALKConversationViewController open to be overridden outside.

## Motivation
<!-- Why are you making this change? -->
Required to show user-info screen using overridden ALKConversationViewController.