### PR TITLE
[AL-3780] Open group improvements and crash fixes.

### DIFF
--- a/ApplozicSwift.podspec
+++ b/ApplozicSwift.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     complete.resources = 'Sources/**/*{lproj,storyboard,xib,xcassets,json}'
     complete.dependency 'Kingfisher', '~> 5.6.0'
     complete.dependency 'MGSwipeTableCell', '~> 1.5.6'
-    complete.dependency 'Applozic', '~> 6.12.0'
+    complete.dependency 'Applozic', '~> 6.14.1'
     complete.dependency 'ApplozicSwift/RichMessageKit'
   end
 end

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -111,6 +111,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                     }
                     cell.menuAction = {[weak self] action in
                         self?.menuItemSelected(action: action, message: message) }
+                    cell.delegate = self
                     return cell
 
                 } else {
@@ -121,6 +122,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                         responseDict in
                         self?.attachmentUploadDidCompleteWith(response: responseDict, indexPath: indexPath)
                     }
+                    cell.delegate = self
                     return cell
                 }
 
@@ -140,12 +142,14 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                     }
                     cell.menuAction = {[weak self] action in
                         self?.menuItemSelected(action: action, message: message) }
+                    cell.delegate = self
                     return cell
 
                 } else {
                     let cell: ALKFriendPhotoLandscapeCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
                     cell.setLocalizedStringFileName(configuration.localizedStringFileName)
                     cell.update(viewModel: message)
+                    cell.delegate = self
                     return cell
                 }
             }
@@ -229,6 +233,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 }
                 cell.menuAction = {[weak self] action in
                     self?.menuItemSelected(action: action, message: message) }
+                cell.delegate = self
                 return cell
             } else {
                 let cell: ALKFriendVideoCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
@@ -244,6 +249,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 }
                 cell.menuAction = {[weak self] action in
                     self?.menuItemSelected(action: action, message: message) }
+                cell.delegate = self
                 return cell
             }
         case .genericCard, .cardTemplate:

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -29,13 +29,12 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
         }
         print("Cell updated at row: ", indexPath.row, "and type is: ", message.messageType)
 
-        guard !message.isReplyMessage else {
+        if let replyMessage = viewModel.replyMessageFor(message: message) {
             // Get reply cell and return
             if message.isMyMessage {
-
                 let cell: ALKMyMessageCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
                 cell.setLocalizedStringFileName(configuration.localizedStringFileName)
-                cell.update(viewModel: message)
+                cell.update(viewModel: message, replyMessage: replyMessage)
                 cell.update(chatBar: self.chatBar)
                 cell.menuAction = {[weak self] action in
                     self?.menuItemSelected(action: action, message: message) }
@@ -43,11 +42,10 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                     self?.scrollTo(message: message)
                 }
                 return cell
-
             } else {
                 let cell: ALKFriendMessageCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
                 cell.setLocalizedStringFileName(configuration.localizedStringFileName)
-                cell.update(viewModel: message)
+                cell.update(viewModel: message, replyMessage: replyMessage)
                 cell.update(chatBar: self.chatBar)
                 cell.avatarTapped = {[weak self] in
                     guard let currentModel = cell.viewModel else {return}
@@ -67,7 +65,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
 
                 let cell: ALKMyMessageCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
                 cell.setLocalizedStringFileName(configuration.localizedStringFileName)
-                cell.update(viewModel: message)
+                cell.update(viewModel: message, replyMessage: nil)
                 cell.update(chatBar: self.chatBar)
                 cell.menuAction = {[weak self] action in
                     self?.menuItemSelected(action: action, message: message) }
@@ -76,7 +74,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
             } else {
                 let cell: ALKFriendMessageCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
                 cell.setLocalizedStringFileName(configuration.localizedStringFileName)
-                cell.update(viewModel: message)
+                cell.update(viewModel: message, replyMessage: nil)
                 cell.update(chatBar: self.chatBar)
                 cell.avatarTapped = {[weak self] in
                     guard let currentModel = cell.viewModel else {return}

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1912,3 +1912,25 @@ extension ALKConversationViewController: NavigationBarCallbacks {
     }
 
 }
+
+extension ALKConversationViewController: AttachmentDelegate {
+    func tapAction(message: ALKMessageViewModel) {
+        let storyboard = UIStoryboard.name(
+            storyboard: UIStoryboard.Storyboard.mediaViewer,
+            bundle: Bundle.applozic)
+        guard let nav = storyboard.instantiateInitialViewController() as? UINavigationController else { return }
+        let vc = nav.viewControllers.first as? ALKMediaViewerViewController
+
+        let messageModels = viewModel.messageModels.filter {
+            $0.messageType == .photo || $0.messageType == .video
+        }
+
+        guard let msg = message as? ALKMessageModel,
+            let currentIndex = messageModels.index(of: msg) else { return }
+        vc?.viewModel = ALKMediaViewerViewModel(
+            messages: messageModels,
+            currentIndex: currentIndex,
+            localizedStringFileName: localizedStringFileName)
+        self.present(nav, animated: true, completion: nil)
+    }
+}

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -355,6 +355,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             alMqttConversationService.mqttConversationDelegate = self
             alMqttConversationService.subscribeToConversation()
         }
+        viewModel.delegate = self
 
         if self.viewModel.isGroup == true {
             let dispName = localizedString(forKey: "Somebody", withDefaultValue: SystemMessage.Chat.somebody, fileName: localizedStringFileName)
@@ -362,9 +363,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         } else {
             self.setTypingNoticeDisplayName(displayName: self.title ?? "")
         }
-
-        viewModel.delegate = self
-        self.refreshViewController()
 
         if let templates = viewModel.getMessageTemplates() {
             templateView = ALKTemplateMessagesView(frame: CGRect.zero, viewModel: ALKTemplateMessagesViewModel(messageTemplates: templates))
@@ -374,9 +372,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         }
         if self.isFirstTime {
             setupView()
-        } else {
-            tableView.reloadData()
+            self.refreshViewController()
         }
+        setupNavigation()
         contentOffsetDictionary = Dictionary<NSObject,AnyObject>()
         print("id: ", viewModel.messageModels.first?.contactId as Any)
     }
@@ -655,12 +653,12 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
 
     private func configureChatBar() {
-        if viewModel.isOpenGroup {
-            chatBar.updateMediaViewVisibility(hide: true)
-            chatBar.hideMicButton()
-        } else {
+//        if viewModel.isOpenGroup {
+//            chatBar.updateMediaViewVisibility(hide: true)
+//            chatBar.hideMicButton()
+//        } else {
             chatBar.updateMediaViewVisibility()
-        }
+//        }
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
@@ -834,7 +832,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         viewModel.clearViewModel()
         tableView.reloadData()
 
-        setupNavigation()
         prepareContextView()
         configureChatBar()
         //Check for group left
@@ -843,6 +840,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         subscribeChannelToMqtt()
 
         viewModel.prepareController()
+        isFirstTime = false
     }
 
     /// Call this before changing viewModel contents

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -374,7 +374,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             setupView()
             self.refreshViewController()
         }
-        setupNavigation()
+        configureView()
         contentOffsetDictionary = Dictionary<NSObject,AnyObject>()
         print("id: ", viewModel.messageModels.first?.contactId as Any)
     }
@@ -831,16 +831,19 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     public func refreshViewController() {
         viewModel.clearViewModel()
         tableView.reloadData()
+        configureView()
+        viewModel.prepareController()
+        isFirstTime = false
+    }
 
+    func configureView() {
+        setupNavigation()
         prepareContextView()
         configureChatBar()
         //Check for group left
         isChannelLeft()
         checkUserBlock()
         subscribeChannelToMqtt()
-
-        viewModel.prepareController()
-        isFirstTime = false
     }
 
     /// Call this before changing viewModel contents

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1049,7 +1049,11 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         guard
             let metadata = message.metadata,
             let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String
-            else {return}
+            else { return }
+        if let indexPath = viewModel.getIndexPathFor(messageKey: replyId) {
+            tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+            return
+        }
         let actualMessage = messageService.getALMessage(byKey: replyId).messageModel
         guard let indexPath = viewModel.getIndexpathFor(message: actualMessage)
             else {return}

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1922,7 +1922,7 @@ extension ALKConversationViewController: AttachmentDelegate {
         let vc = nav.viewControllers.first as? ALKMediaViewerViewController
 
         let messageModels = viewModel.messageModels.filter {
-            $0.messageType == .photo || $0.messageType == .video
+            ($0.messageType == .photo || $0.messageType == .video) && ($0.downloadPath() != nil) && ($0.downloadPath()!.1 != nil)
         }
 
         guard let msg = message as? ALKMessageModel,

--- a/Sources/Utilities/ALKMessageViewModel+Extension.swift
+++ b/Sources/Utilities/ALKMessageViewModel+Extension.swift
@@ -80,17 +80,21 @@ extension ALKMessageViewModel {
     }
 
     func downloadPath() -> (String, NSData?)? {
+        let url = FileManager.default.urls(for: .documentDirectory,
+                                           in: .userDomainMask)[0]
+        /// Check if message is present in db.
+        if let filePath = self.filePath {
+            return (filePath, NSData(contentsOfFile: url.appendingPathComponent(filePath).path))
+        }
         guard
             let name = fileMetaInfo?.name,
             let fileExtension = name.components(separatedBy: ".").last
             else {
                 return nil
         }
-        let filePath = String(format: "%@_local.%@", identifier, fileExtension)
-        let url = FileManager.default.urls(for: .documentDirectory,
-                                           in: .userDomainMask)[0]
-        let data = NSData(contentsOfFile: url.appendingPathComponent(filePath).path)
-        return (filePath, data)
+        let path = String(format: "%@_local.%@", identifier, fileExtension)
+        let data = NSData(contentsOfFile: url.appendingPathComponent(path).path)
+        return (path, data)
     }
 
     func attachmentState() -> AttachmentState? {

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -332,7 +332,7 @@ extension ALMessage {
         return self.fileMeta ?? nil
     }
 
-    private func getAttachmentType() -> ALKMessageType? {
+    func getAttachmentType() -> ALKMessageType? {
         guard let fileMeta = fileMeta else {return nil}
         if fileMeta.contentType.hasPrefix("image") {
             return .photo

--- a/Sources/Utilities/ALMessageDBService+Extension.swift
+++ b/Sources/Utilities/ALMessageDBService+Extension.swift
@@ -9,9 +9,8 @@ import Applozic
 
 extension ALMessageDBService {
     func updateDbMessageWith(key: String, value: String, filePath: String) {
-        let messageService = ALMessageDBService()
         let alHandler = ALDBHandler.sharedInstance()
-        guard let dbMessage: DB_Message = messageService.getMessageByKey(key, value: value) as? DB_Message else {
+        guard let dbMessage = getMessageByKey(key, value: value) as? DB_Message else {
             print("Can't find message with key \(key) and value \(value)")
             return
         }

--- a/Sources/Utilities/Int+Extension.swift
+++ b/Sources/Utilities/Int+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  Int+Extension.swift
+//  ApplozicSwift
+//
+//  Created by Shivam Pokhriyal on 23/07/19.
+//
+
+import Foundation
+
+extension Int64 {
+    func degree(outOf total: Int64) -> Double {
+        let divergence = Double(total)/360.0
+        let degree = Double(self)/divergence
+        return degree
+    }
+}

--- a/Sources/Utilities/ReplyImage.swift
+++ b/Sources/Utilities/ReplyImage.swift
@@ -1,0 +1,66 @@
+//
+//  ReplyImage.swift
+//  ApplozicSwift
+//
+//  Created by Shivam Pokhriyal on 14/08/19.
+//
+
+import UIKit
+import Applozic
+
+public struct ReplyMessageImage {
+
+    let videoPlaceholder = UIImage(named: "VIDEO", in: Bundle.applozic, compatibleWith: nil)
+
+    let locationPlaceholder = UIImage(named: "map_no_data", in: Bundle.applozic, compatibleWith: nil)
+
+    let imagePlaceholder = UIImage(named: "photo", in: Bundle.applozic, compatibleWith: nil)
+
+    private func getVideoThumbnail(filePath: URL) -> UIImage? {
+        do {
+            let asset = AVURLAsset(url: filePath , options: nil)
+            let imgGenerator = AVAssetImageGenerator(asset: asset)
+            imgGenerator.appliesPreferredTrackTransform = true
+            let cgImage = try imgGenerator.copyCGImage(at: CMTimeMake(value: 0, timescale: 1), actualTime: nil)
+            return UIImage(cgImage: cgImage)
+        } catch let error {
+            print("*** Error generating thumbnail: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func previewFor(message: ALKMessageViewModel) -> (URL?, UIImage?) {
+        var url: URL? = nil
+        switch message.messageType {
+        case .photo:
+            if let filePath = message.filePath {
+                let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                url = docDirPath.appendingPathComponent(filePath)
+            } else {
+                url = message.thumbnailURL
+            }
+            return (url, imagePlaceholder)
+        case .video:
+            var image = videoPlaceholder
+            if let filepath = message.filePath {
+                let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                let path = docDirPath.appendingPathComponent(filepath)
+                image = getVideoThumbnail(filePath: path) ?? videoPlaceholder
+            }
+            return (nil, image)
+        case .location:
+            guard let lat = message.geocode?.location.latitude,
+                let lon = message.geocode?.location.longitude
+                else { return (nil, locationPlaceholder) }
+
+            let latLonArgument = String(format: "%f,%f", lat, lon)
+            guard let apiKey = ALUserDefaultsHandler.getGoogleMapAPIKey()
+                else { return (nil, locationPlaceholder) }
+            // swiftlint:disable:next line_length
+            let urlString = "https://maps.googleapis.com/maps/api/staticmap?center=\(latLonArgument)&zoom=17&size=375x295&maptype=roadmap&format=png&visual_refresh=true&markers=\(latLonArgument)&key=\(apiKey)"
+            return (URL(string: urlString), locationPlaceholder)
+        default:
+            return (nil, nil)
+        }
+    }
+}

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1245,14 +1245,17 @@ open class ALKConversationViewModel: NSObject, Localizable {
 
             let contactDbService = ALContactDBService()
             contactDbService.addUserDetails(userDetailsList)
-            guard let alMessages = messages as? [ALMessage] else {
+            guard var alMessages = messages as? [ALMessage] else {
                 completion(nil)
                 return
             }
             let contactService = ALContactService()
+            let messageDbService = ALMessageDBService()
             var contactsNotPresent = [String]()
             var replyMessageKeys = [String]()
-            for message in alMessages {
+
+            for index in 0..<alMessages.count {
+                let message = alMessages[index]
                 let contactId = message.to ?? ""
                 if !contactService.isContactExist(contactId) {
                     contactsNotPresent.append(contactId)
@@ -1260,6 +1263,14 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 if let metadata = message.metadata,
                     let key = metadata[AL_MESSAGE_REPLY_KEY] as? String {
                     replyMessageKeys.append(key)
+                }
+                if message.getAttachmentType() != nil {
+let dbMessage = messageDbService.getMessageByKey("key", value: message.identifier) as? DB_Message
+                }
+                if message.getAttachmentType() != nil,
+                    let dbMessage = messageDbService.getMessageByKey("key", value: message.identifier) as? DB_Message,
+                    dbMessage.filePath != nil {
+                    alMessages[index] = messageDbService.createMessageEntity(dbMessage)
                 }
             }
             if !replyMessageKeys.isEmpty {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1261,14 +1261,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
 
     private func updateDbMessageWith(key: String, value: String, filePath: String) {
         let messageService = ALMessageDBService()
-        let alHandler = ALDBHandler.sharedInstance()
-        let dbMessage: DB_Message = messageService.getMessageByKey(key, value: value) as! DB_Message
-        dbMessage.filePath = filePath
-        do {
-            try alHandler?.managedObjectContext.save()
-        } catch {
-            NSLog("Not saved due to error")
-        }
+        messageService.updateDbMessageWith(key: key, value: value, filePath: filePath)
     }
 
     private func getMessageToPost(isTextMessage: Bool = false) -> ALMessage {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1026,6 +1026,15 @@ open class ALKConversationViewModel: NSObject, Localizable {
         return IndexPath(row: 0, section: index)
     }
 
+    open func getIndexPathFor(messageKey: String) -> IndexPath? {
+        for (index, value) in messageModels.enumerated() {
+            if value.identifier == messageKey {
+                return IndexPath(row: 0, section: index)
+            }
+        }
+        return nil
+    }
+
     open func genericTemplateFor(message: ALKMessageViewModel) -> Any? {
 
         guard richMessages[message.identifier] == nil else {
@@ -1281,9 +1290,6 @@ open class ALKConversationViewModel: NSObject, Localizable {
                     let key = metadata[AL_MESSAGE_REPLY_KEY] as? String {
                     replyMessageKeys.append(key)
                 }
-                if message.getAttachmentType() != nil {
-let dbMessage = messageDbService.getMessageByKey("key", value: message.identifier) as? DB_Message
-                }
                 if message.getAttachmentType() != nil,
                     let dbMessage = messageDbService.getMessageByKey("key", value: message.identifier) as? DB_Message,
                     dbMessage.filePath != nil {
@@ -1292,7 +1298,10 @@ let dbMessage = messageDbService.getMessageByKey("key", value: message.identifie
             }
             if !replyMessageKeys.isEmpty {
                 ALMessageService().fetchReplyMessages(NSMutableArray(array: replyMessageKeys), withCompletion: { (replyMessages) in
-                    guard let replyMessages = replyMessages as? [ALMessage] else { return }
+                    guard let replyMessages = replyMessages as? [ALMessage] else {
+                        completion(alMessages)
+                        return
+                    }
                     for message in replyMessages {
                         let contactId = message.to ?? ""
                         if !contactService.isContactExist(contactId) {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -191,6 +191,15 @@ open class ALKConversationViewModel: NSObject, Localizable {
         return messageModels[indexPath.section]
     }
 
+    open func replyMessageFor(message: ALKMessageViewModel) -> ALKMessageViewModel? {
+        guard let metadata = message.metadata,
+            let replyKey = metadata[AL_MESSAGE_REPLY_KEY] as? String
+        else {
+            return nil
+        }
+        return messageForRow(identifier: replyKey) ?? ALMessageService().getALMessage(byKey: replyKey)?.messageModel
+    }
+
     open func quickReplyDictionary(message: ALKMessageViewModel?,indexRow row: Int) -> Dictionary<String,Any>? {
 
         guard let metadata = message?.metadata else {
@@ -234,11 +243,12 @@ open class ALKConversationViewModel: NSObject, Localizable {
         }
         switch messageModel.messageType {
         case .text, .html, .email:
+            let replyMessage = replyMessageFor(message: messageModel)
             if messageModel.isMyMessage {
-                let height = ALKMyMessageCell.rowHeigh(viewModel: messageModel, width: maxWidth)
+                let height = ALKMyMessageCell.rowHeigh(viewModel: messageModel, width: maxWidth, replyMessage: replyMessage)
                 return height.cached(with: messageModel.identifier)
             } else {
-                let height = ALKFriendMessageCell.rowHeigh(viewModel: messageModel, width: maxWidth)
+                let height = ALKFriendMessageCell.rowHeigh(viewModel: messageModel, width: maxWidth, replyMessage: replyMessage)
                 return height.cached(with: messageModel.identifier)
             }
         case .photo:

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -595,10 +595,17 @@ open class ALKConversationViewModel: NSObject, Localizable {
         self.delegate?.messageSent(at: indexPath)
         if isOpenGroup {
             let messageClientService = ALMessageClientService()
-            messageClientService.sendMessage(alMessage.dictionary(), withCompletionHandler: {_, error in
-                guard error == nil, indexPath.section < self.messageModels.count else { return }
-                NSLog("No errors while sending the message in open group")
-                alMessage.status = NSNumber(integerLiteral: Int(SENT.rawValue))
+            messageClientService.sendMessage(alMessage.dictionary(), withCompletionHandler: {json, error in
+                guard error == nil,
+                    indexPath.section < self.messageModels.count,
+                    let json = json as? [String: Any]
+                    else { return }
+                if let response = json["response"] as? [String: Any], let key = response["messageKey"] as? String {
+                    alMessage.key = key
+                    alMessage.status = NSNumber(integerLiteral: Int(SENT.rawValue))
+                } else {
+                    alMessage.status = NSNumber(integerLiteral: Int(PENDING.rawValue))
+                }
                 self.messageModels[indexPath.section] = alMessage.messageModel
                 self.delegate?.updateMessageAt(indexPath: indexPath)
                 return

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1131,9 +1131,11 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 self.delegate?.loadingFinished(error: nil)
                 return
             }
-            self.alMessages = messages
-            self.alMessageWrapper.addObject(toMessageArray: NSMutableArray(array: messages))
-            let models = messages.map { $0.messageModel }
+            let sortedArray = messages.sorted { Int(truncating: $0.createdAtTime) < Int(truncating: $1.createdAtTime) }
+            guard !sortedArray.isEmpty else { return }
+            self.alMessages = sortedArray
+            self.alMessageWrapper.addObject(toMessageArray: NSMutableArray(array: sortedArray))
+            let models = sortedArray.map { $0.messageModel }
             self.messageModels = models
             if self.isFirstTime {
                 self.delegate?.loadingFinished(error: nil)

--- a/Sources/Views/ALKDocumentCell.swift
+++ b/Sources/Views/ALKDocumentCell.swift
@@ -44,13 +44,6 @@ ALKReplyMenuItemProtocol {
         }
     }
 
-    enum State {
-        case download
-        case downloading(progress: Double, totalCount: Int64)
-        case downloaded(filePath: String)
-        case upload
-    }
-
     var uploadTapped:((Bool)->Void)?
     var uploadCompleted: ((_ responseDict: Any?)->Void)?
     var downloadTapped:((Bool)->Void)?
@@ -224,30 +217,15 @@ ALKReplyMenuItemProtocol {
             sizeAndFileType.text =  size + " \u{2022} " + fileType
         }
 
-        if viewModel.isMyMessage {
-            if viewModel.isSent || viewModel.isAllRead || viewModel.isAllReceived {
-                if let filePath = viewModel.filePath, !filePath.isEmpty {
-                    updateView(for: State.downloaded(filePath: filePath))
-                } else {
-                    updateView(for: State.download)
-                }
-            } else {
-                updateView(for: .upload)
-            }
-        } else {
-            if let filePath = viewModel.filePath, !filePath.isEmpty {
-                updateView(for: State.downloaded(filePath: filePath))
-            } else {
-                updateView(for: State.download)
-            }
-        }
+        guard let state = viewModel.attachmentState() else { return }
+        updateView(for: state)
     }
 
     @objc private func downloadButtonAction(_ selector: UIButton) {
         downloadTapped?(true)
     }
 
-    func updateView(for state: State) {
+    func updateView(for state: AttachmentState) {
         switch state {
         case .download:
             downloadButton.isHidden = false
@@ -264,25 +242,8 @@ ALKReplyMenuItemProtocol {
         case .upload:
             downloadButton.isHidden = true
             progressView.isHidden = true
-        }
-    }
-
-    fileprivate func convertToDegree(total: Int64, written: Int64) -> Double {
-        let divergence = Double(total)/360.0
-        let degree = Double(written)/divergence
-        return degree
-
-    }
-
-    fileprivate func updateDbMessageWith(key: String, value: String, filePath: String) {
-        let messageService = ALMessageDBService()
-        let alHandler = ALDBHandler.sharedInstance()
-        let dbMessage: DB_Message = messageService.getMessageByKey(key, value: value) as! DB_Message
-        dbMessage.filePath = filePath
-        do {
-            try alHandler?.managedObjectContext.save()
-        } catch {
-            print("Not saved due to error")
+        default:
+            print("Not handled")
         }
     }
 
@@ -292,7 +253,7 @@ extension ALKDocumentCell: ALKHTTPManagerUploadDelegate {
 
     func dataUploaded(task: ALKUploadTask) {
         print("Data uploaded: \(task.totalBytesUploaded) out of total: \(task.totalBytesExpectedToUpload)")
-        let progress = self.convertToDegree(total: task.totalBytesExpectedToUpload, written: task.totalBytesUploaded)
+        let progress = task.totalBytesUploaded.degree(outOf: task.totalBytesExpectedToUpload)
         self.updateView(for: .downloading(progress: progress, totalCount: task.totalBytesExpectedToUpload))
     }
 
@@ -300,7 +261,7 @@ extension ALKDocumentCell: ALKHTTPManagerUploadDelegate {
         print("Document CELL DATA UPLOADED FOR PATH: %@", viewModel?.filePath ?? "")
         if task.uploadError == nil && task.completed == true && task.filePath != nil {
             DispatchQueue.main.async {
-                self.updateView(for: State.downloaded(filePath: task.filePath ?? ""))
+                self.updateView(for: .downloaded(filePath: task.filePath ?? ""))
             }
         } else {
             DispatchQueue.main.async {
@@ -314,7 +275,7 @@ extension ALKDocumentCell: ALKHTTPManagerDownloadDelegate {
     func dataDownloaded(task: ALKDownloadTask) {
         print("Document CELL DATA UPDATED AND FILEPATH IS", viewModel?.filePath ?? "")
         let total = task.totalBytesExpectedToDownload
-        let progress = self.convertToDegree(total: total, written: task.totalBytesDownloaded)
+        let progress = task.totalBytesDownloaded.degree(outOf: total)
         self.updateView(for: .downloading(progress: progress, totalCount: total))
     }
 
@@ -325,7 +286,7 @@ extension ALKDocumentCell: ALKHTTPManagerDownloadDelegate {
             }
             return
         }
-        self.updateDbMessageWith(key: "key", value: identifier, filePath: filePath)
+        ALMessageDBService().updateDbMessageWith(key: "key", value: identifier, filePath: filePath)
         DispatchQueue.main.async {
             self.updateView(for: .downloaded(filePath: filePath))
         }

--- a/Sources/Views/ALKFriendMessageCell.swift
+++ b/Sources/Views/ALKFriendMessageCell.swift
@@ -240,9 +240,9 @@ open class ALKFriendMessageCell: ALKMessageCell {
         }
     }
 
-    override func update(viewModel: ALKMessageViewModel) {
-        super.update(viewModel: viewModel, style: ALKMessageStyle.receivedMessage)
-        handleReplyView(viewModel: viewModel)
+    func update(viewModel: ALKMessageViewModel, replyMessage: ALKMessageViewModel?) {
+        super.update(viewModel: viewModel, style: ALKMessageStyle.receivedMessage, replyMessage: replyMessage)
+        handleReplyView(replyMessage: replyMessage)
         let placeHolder = UIImage(named: "placeholder", in: Bundle.applozic, compatibleWith: nil)
         if let url = viewModel.avatarURL {
             let resource = ImageResource(downloadURL: url, cacheKey: url.absoluteString)
@@ -254,8 +254,9 @@ open class ALKFriendMessageCell: ALKMessageCell {
         nameLabel.text = viewModel.displayName
     }
 
-    override class func rowHeigh(viewModel: ALKMessageViewModel,
-                                 width: CGFloat) -> CGFloat {
+    class func rowHeigh(viewModel: ALKMessageViewModel,
+                        width: CGFloat,
+                        replyMessage: ALKMessageViewModel?) -> CGFloat {
         let minimumHeight = Padding.AvatarImage.top + Padding.AvatarImage.height + 5
 
         /// Calculating available width for messageView
@@ -269,14 +270,7 @@ open class ALKFriendMessageCell: ALKMessageCell {
 
         let totalHeight = max((messageHeight + heightPadding), minimumHeight)
 
-        guard
-            let metadata = viewModel.metadata,
-            let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String,
-            let actualMessage = ALMessageService().getALMessage(byKey: replyId)?.messageModel,
-            !actualMessage.identifier.isEmpty
-            else {
-                return totalHeight
-        }
+        guard replyMessage != nil else { return totalHeight }
         return totalHeight + Padding.ReplyView.height
     }
 
@@ -299,25 +293,16 @@ open class ALKFriendMessageCell: ALKMessageCell {
         }
     }
 
-    private func handleReplyView(viewModel: ALKMessageViewModel) {
-        if viewModel.isReplyMessage {
-            guard
-                let metadata = viewModel.metadata,
-                let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String,
-                let actualMessage = getMessageFor(key: replyId),
-                !actualMessage.identifier.isEmpty
-            else {
-                showReplyView(false)
-                return
-            }
-            showReplyView(true)
-            if actualMessage.messageType == .text || actualMessage.messageType == .html {
-                previewImageView.constraint(withIdentifier: ConstraintIdentifier.replyPreviewImageWidth)?.constant = 0
-            } else {
-                previewImageView.constraint(withIdentifier: ConstraintIdentifier.replyPreviewImageWidth)?.constant = Padding.PreviewImageView.width
-            }
-        } else {
+    private func handleReplyView(replyMessage: ALKMessageViewModel?) {
+        guard let replyMessage = replyMessage else {
             showReplyView(false)
+            return
+        }
+        showReplyView(true)
+        if replyMessage.messageType == .text || replyMessage.messageType == .html {
+            previewImageView.constraint(withIdentifier: ConstraintIdentifier.replyPreviewImageWidth)?.constant = 0
+        } else {
+            previewImageView.constraint(withIdentifier: ConstraintIdentifier.replyPreviewImageWidth)?.constant = Padding.PreviewImageView.width
         }
     }
 

--- a/Sources/Views/ALKMessageBaseCell.swift
+++ b/Sources/Views/ALKMessageBaseCell.swift
@@ -143,16 +143,18 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
             guard
                 let metadata = viewModel.metadata,
                 let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String,
-                let actualMessage = getMessageFor(key: replyId)
+                let actualMessage = getMessageFor(key: replyId),
+                actualMessage.identifier != nil
                 else { return }
             replyNameLabel.text = actualMessage.isMyMessage ?
                 selfNameText : actualMessage.displayName
             replyMessageLabel.text =
                 getMessageTextFrom(viewModel: actualMessage)
-            if let imageURL = getURLForPreviewImage(message: actualMessage) {
-                setImageFrom(url: imageURL, to: previewImageView)
+            let (url, image) = ReplyMessageImage().previewFor(message: actualMessage)
+            if let url = url {
+                setImageFrom(url: url, to: previewImageView)
             } else {
-                previewImageView.image = placeholderForPreviewImage(message: actualMessage)
+                previewImageView.image = image
             }
         } else {
             replyNameLabel.text = ""
@@ -289,6 +291,30 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
 
     // MARK: - Private helper methods
 
+    private func handleReplyMessage(viewModel: ALKMessageViewModel) {
+        replyNameLabel.text = ""
+        replyMessageLabel.text = ""
+        previewImageView.image = nil
+        if viewModel.isReplyMessage {
+            guard
+                let metadata = viewModel.metadata,
+                let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String,
+                let actualMessage = getMessageFor(key: replyId),
+                !actualMessage.identifier.isEmpty
+                else { return }
+            replyNameLabel.text = actualMessage.isMyMessage ?
+                selfNameText : actualMessage.displayName
+            replyMessageLabel.text =
+                getMessageTextFrom(viewModel: actualMessage)
+            let (url, image) = ReplyMessageImage().previewFor(message: actualMessage)
+            if let url = url {
+                setImageFrom(url: url, to: previewImageView)
+            } else {
+                previewImageView.image = image
+            }
+        }
+    }
+
     private class func attributedStringFrom(_ text: String, for id: String) -> NSAttributedString? {
         if let attributedString = attributedStringCache.object(forKey: id as NSString) {
             return attributedString
@@ -340,74 +366,6 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
         let provider = LocalFileImageDataProvider(fileURL: url)
         imageView.kf.setImage(with: provider)
     }
-
-    private func getURLForPreviewImage(message: ALKMessageViewModel) -> URL? {
-        switch message.messageType {
-        case .photo, .video:
-            return getImageURL(for: message)
-        case .location:
-            return getMapImageURL(for: message)
-        default:
-            return nil
-        }
-    }
-
-    private func getImageURL(for message: ALKMessageViewModel) -> URL? {
-        guard message.messageType == .photo else {return nil}
-        if let filePath = message.filePath {
-            let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            let path = docDirPath.appendingPathComponent(filePath)
-            return path
-        } else if let thumnailURL = message.thumbnailURL {
-            return thumnailURL
-        }
-        return nil
-    }
-
-    private func getMapImageURL(for message: ALKMessageViewModel) -> URL?  {
-        guard message.messageType == .location else {return nil}
-        guard let lat = message.geocode?.location.latitude,
-            let lon = message.geocode?.location.longitude
-            else { return nil }
-
-        let latLonArgument = String(format: "%f,%f", lat, lon)
-        guard let apiKey = ALUserDefaultsHandler.getGoogleMapAPIKey()
-            else { return nil }
-        let urlString = "https://maps.googleapis.com/maps/api/staticmap?center=\(latLonArgument)&zoom=17&size=375x295&maptype=roadmap&format=png&visual_refresh=true&markers=\(latLonArgument)&key=\(apiKey)"
-        return URL(string: urlString)
-
-    }
-
-    private func placeholderForPreviewImage(message: ALKMessageViewModel) -> UIImage? {
-        switch message.messageType {
-        case .video:
-            if let filepath = message.filePath {
-                let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-                let path = docDirPath.appendingPathComponent(filepath)
-                return getThumbnail(filePath: path)
-            }
-            return UIImage(named: "VIDEO", in: Bundle.applozic, compatibleWith: nil)
-        case .location:
-            return UIImage(named: "map_no_data", in: Bundle.applozic, compatibleWith: nil)
-        default:
-            return nil
-        }
-    }
-
-    private func getThumbnail(filePath: URL) -> UIImage? {
-        do {
-            let asset = AVURLAsset(url: filePath , options: nil)
-            let imgGenerator = AVAssetImageGenerator(asset: asset)
-            imgGenerator.appliesPreferredTrackTransform = true
-            let cgImage = try imgGenerator.copyCGImage(at: CMTimeMake(value: 0, timescale: 1), actualTime: nil)
-            return UIImage(cgImage: cgImage)
-
-        } catch let error {
-            print("*** Error generating thumbnail: \(error.localizedDescription)")
-            return nil
-        }
-    }
-
 
     /// This hack is required cuz textView won't clear its attributes.
     /// See this: https://stackoverflow.com/q/21731207/6671572

--- a/Sources/Views/ALKMessageBaseCell.swift
+++ b/Sources/Views/ALKMessageBaseCell.swift
@@ -136,21 +136,15 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
 
     var replyViewAction: (()->())? = nil
 
-    func update(viewModel: ALKMessageViewModel, style: Style) {
+    func update(viewModel: ALKMessageViewModel, style: Style, replyMessage: ALKMessageViewModel?) {
         self.viewModel = viewModel
 
-        if viewModel.isReplyMessage {
-            guard
-                let metadata = viewModel.metadata,
-                let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String,
-                let actualMessage = getMessageFor(key: replyId),
-                actualMessage.identifier != nil
-                else { return }
-            replyNameLabel.text = actualMessage.isMyMessage ?
-                selfNameText : actualMessage.displayName
+        if let replyMessage = replyMessage {
+            replyNameLabel.text = replyMessage.isMyMessage ?
+                selfNameText : replyMessage.displayName
             replyMessageLabel.text =
-                getMessageTextFrom(viewModel: actualMessage)
-            let (url, image) = ReplyMessageImage().previewFor(message: actualMessage)
+                getMessageTextFrom(viewModel: replyMessage)
+            let (url, image) = ReplyMessageImage().previewFor(message: replyMessage)
             if let url = url {
                 setImageFrom(url: url, to: previewImageView)
             } else {
@@ -262,11 +256,6 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
         menuAction?(.reply)
     }
 
-    func getMessageFor(key: String) -> ALKMessageViewModel? {
-        let messageService = ALMessageService()
-        return messageService.getALMessage(byKey: key)?.messageModel
-    }
-
     @objc func replyViewTapped() {
         replyViewAction?()
     }
@@ -290,30 +279,6 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel>, ALKCopyMenuItem
     }
 
     // MARK: - Private helper methods
-
-    private func handleReplyMessage(viewModel: ALKMessageViewModel) {
-        replyNameLabel.text = ""
-        replyMessageLabel.text = ""
-        previewImageView.image = nil
-        if viewModel.isReplyMessage {
-            guard
-                let metadata = viewModel.metadata,
-                let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String,
-                let actualMessage = getMessageFor(key: replyId),
-                !actualMessage.identifier.isEmpty
-                else { return }
-            replyNameLabel.text = actualMessage.isMyMessage ?
-                selfNameText : actualMessage.displayName
-            replyMessageLabel.text =
-                getMessageTextFrom(viewModel: actualMessage)
-            let (url, image) = ReplyMessageImage().previewFor(message: actualMessage)
-            if let url = url {
-                setImageFrom(url: url, to: previewImageView)
-            } else {
-                previewImageView.image = image
-            }
-        }
-    }
 
     private class func attributedStringFrom(_ text: String, for id: String) -> NSAttributedString? {
         if let attributedString = attributedStringCache.object(forKey: id as NSString) {

--- a/Sources/Views/ALKMyDocumentCell.swift
+++ b/Sources/Views/ALKMyDocumentCell.swift
@@ -97,15 +97,4 @@ class ALKMyDocumentCell: ALKDocumentCell {
         return max(messageHeight, minimumHeight)
     }
 
-    fileprivate func updateDbMessageWith(key: String, value: String, filePath: String) {
-        let messageService = ALMessageDBService()
-        let alHandler = ALDBHandler.sharedInstance()
-        let dbMessage: DB_Message = messageService.getMessageByKey(key, value: value) as! DB_Message
-        dbMessage.filePath = filePath
-        do {
-            try alHandler?.managedObjectContext.save()
-        } catch {
-            print("Not saved file path due to error")
-        }
-    }
 }

--- a/Sources/Views/ALKMyMessageCell.swift
+++ b/Sources/Views/ALKMyMessageCell.swift
@@ -203,9 +203,9 @@ open class ALKMyMessageCell: ALKMessageCell {
         }
     }
 
-   open override func update(viewModel: ALKMessageViewModel) {
-        super.update(viewModel: viewModel, style: ALKMessageStyle.sentMessage)
-        handleReplyView(viewModel: viewModel)
+   open func update(viewModel: ALKMessageViewModel, replyMessage: ALKMessageViewModel?) {
+        super.update(viewModel: viewModel, style: ALKMessageStyle.sentMessage, replyMessage: replyMessage)
+        handleReplyView(replyMessage: replyMessage)
         if viewModel.isAllRead {
             stateView.image = UIImage(named: "read_state_3", in: Bundle.applozic, compatibleWith: nil)
             stateView.tintColor = UIColor(netHex: 0x0578FF)
@@ -221,8 +221,9 @@ open class ALKMyMessageCell: ALKMessageCell {
         }
     }
 
-    override class func rowHeigh(viewModel: ALKMessageViewModel,
-                                 width: CGFloat) -> CGFloat {
+    class func rowHeigh(viewModel: ALKMessageViewModel,
+                        width: CGFloat,
+                        replyMessage: ALKMessageViewModel?) -> CGFloat {
         /// Calculating messageHeight
         let leftSpacing = Padding.BubbleView.left + ALKMessageStyle.sentBubble.widthPadding
         let rightSpacing = Padding.BubbleView.right + bubbleViewRightPadding
@@ -231,36 +232,20 @@ open class ALKMyMessageCell: ALKMessageCell {
         let heightPadding = Padding.MessageView.top + Padding.MessageView.bottom + Padding.BubbleView.bottom + Padding.ReplyView.top
 
         let totalHeight = messageHeight + heightPadding
-        guard
-            let metadata = viewModel.metadata,
-            let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String,
-            let actualMessage = ALMessageService().getALMessage(byKey: replyId)?.messageModel,
-            !actualMessage.identifier.isEmpty
-            else {
-                return totalHeight
-        }
+        guard replyMessage != nil else { return totalHeight }
         return totalHeight + Padding.ReplyView.height
     }
 
-    private func handleReplyView(viewModel: ALKMessageViewModel) {
-        if viewModel.isReplyMessage {
-            guard
-                let metadata = viewModel.metadata,
-                let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String,
-                let actualMessage = getMessageFor(key: replyId),
-                !actualMessage.identifier.isEmpty
-            else {
-                showReplyView(false)
-                return
-            }
-            showReplyView(true)
-            if actualMessage.messageType == .text || actualMessage.messageType == .html {
-                previewImageView.constraint(withIdentifier: ConstraintIdentifier.PreviewImage.width)?.constant = 0
-            } else {
-                previewImageView.constraint(withIdentifier: ConstraintIdentifier.PreviewImage.width)?.constant = Padding.PreviewImageView.width
-            }
-        } else {
+    private func handleReplyView(replyMessage: ALKMessageViewModel?) {
+        guard let replyMessage = replyMessage else {
             showReplyView(false)
+            return
+        }
+        showReplyView(true)
+        if replyMessage.messageType == .text || replyMessage.messageType == .html {
+            previewImageView.constraint(withIdentifier: ConstraintIdentifier.PreviewImage.width)?.constant = 0
+        } else {
+            previewImageView.constraint(withIdentifier: ConstraintIdentifier.PreviewImage.width)?.constant = Padding.PreviewImageView.width
         }
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
This PR will add following changes: 
1. The code to check whether attachment is downloaded or not is changed. Now, we will directly query the file system to check if the file exists or not and update view accordingly.
2. Moved code to open MediaViewerController to ConversationController from cells. It will show all the medias that are downloaded in that conversation.
3. Updated loading of messages for Open group to load earlier messages when scrolling up and refresh when refresh button is clicked.
4. Support uploading of attachments in Open group. 
5. Support reply messages in open group.

##Instructions to use:
- Clone [this repo](https://github.com/AppLozic/Applozic-Chat-iOS-Framework/tree/reply-api) in your local.
- Now open your Podfile and add following dependency alongwith ApplozicSwift's dependency
`pod 'Applozic', :path => 'PATH_TO_THE_CLONED_REPO'`
So that it will look like
`pod 'Applozic', :path => '/Users/shivampokhriyal/Desktop/framework/Applozic-Chat-iOS-Framework'`


**Need to hide attachment upload in Open Group before merging**