### PR TITLE
Fix compiler issue for older XCode #trivial

### DIFF
--- a/Sources/Controllers/ALKCreateGroupViewController.swift
+++ b/Sources/Controllers/ALKCreateGroupViewController.swift
@@ -402,13 +402,13 @@ extension ALKCreateGroupViewController: ALKCreateGroupViewModelDelegate {
 
     func sendMessage(at index: Int) {
         let member = viewModel.rowAt(index: index)
-        let viewModel = ALKConversationViewModel(
+        let conversationViewModel = ALKConversationViewModel(
             contactId: member.id,
             channelKey: nil,
             localizedStringFileName: localizedStringFileName)
 
         let conversationVC = ALKConversationViewController(configuration: configuration)
-        conversationVC.viewModel = viewModel
+        conversationVC.viewModel = conversationViewModel
         self.navigationController?.pushViewController(conversationVC, animated: true)
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
In XCode version < 10.2, compiler was giving error "variable viewmodel used before declaration". THis PR will fix this compiler error.