### PR TITLE
[AL-3624] Added support for restricting certain messages using regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - [AL-3577] Added Option to report a message;
 - [AL-3540]Add custom button in navigation bar
 - [AL-3210] Added RTL support.
+- [AL-3624] Added support for passing regular expression pattern to restrict certain messages.
 
 3.0.0
 ---

--- a/Demo/ApplozicSwiftDemoTests/Tests/ProfanityFilterTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ProfanityFilterTests.swift
@@ -15,27 +15,64 @@ class ProfanityFilterTests: XCTestCase {
         fileName: "restrictedWords",
         bundle: Bundle(for: ProfanityFilterTests.self))
 
-    override func setUp() {
-    }
-
-    func testUppercaseText() {
+    func test_whenUppercaseText() {
         XCTAssertTrue(profanityFilter.containsRestrictedWords(text: "BADWORD"))
     }
 
-    func testAllLowercaseText() {
+    func test_whenAllLowercaseText() {
         XCTAssertTrue(profanityFilter.containsRestrictedWords(text: "badword here"))
     }
 
-    func testUppercaseAndLowercaseTextCombination() {
+    func test_whenUppercaseAndLowercaseTextCombination() {
         XCTAssertTrue(profanityFilter.containsRestrictedWords(text: "badWOrd here"))
     }
 
-    func testUppercaseInFileWithLowerCaseInText() {
+    func test_whenUppercaseInFileWithLowerCaseInText() {
         // In file it is: bestBadWord
         XCTAssertTrue(profanityFilter.containsRestrictedWords(text: "bestbadword"))
     }
 
-    func testWhenWordContainsExtraCharacters() {
+    func test_whenWordContainsExtraCharacters() {
         XCTAssertFalse(profanityFilter.containsRestrictedWords(text: "--badWord"))
+    }
+
+    func test_whenMatchingWordIsInTheEnd() {
+        XCTAssertTrue(profanityFilter.containsRestrictedWords(text: "hello badWord"))
+    }
+
+    func test_whenMatchIsPresent() {
+        let profanityFilterWithRegex = try! ProfanityFilter(
+            restrictedMessageRegex: "\\d{10}",
+            bundle: Bundle(for: ProfanityFilterTests.self))
+        XCTAssertTrue(profanityFilterWithRegex
+            .containsRestrictedWords(text: "hello 9299999999"))
+    }
+
+    func test_whenMatchIsNotPresent() {
+        let profanityFilterWithRegex = try! ProfanityFilter(
+            restrictedMessageRegex: "\\d{10}",
+            bundle: Bundle(for: ProfanityFilterTests.self))
+        XCTAssertFalse(profanityFilterWithRegex
+            .containsRestrictedWords(text: "hello 929999"))
+    }
+
+    func test_whenMatchesAndRestrictedWordsBothArePresent() {
+        let profanityFilterWithRegex = try! ProfanityFilter(
+            fileName: "restrictedWords",
+            restrictedMessageRegex: "\\d{10}",
+            bundle: Bundle(for: ProfanityFilterTests.self))
+        XCTAssertTrue(profanityFilterWithRegex
+            .containsRestrictedWords(text: "hello 929999999 badword"))
+    }
+
+    func test_whenRegexPatternIsInvalid() {
+
+        // "}" is missing in the end
+        let invalidPattern = "\\d{10"
+        let profanityFilterWithRegex = try! ProfanityFilter(
+            restrictedMessageRegex: invalidPattern,
+            bundle: Bundle(for: ProfanityFilterTests.self))
+        XCTAssertFalse(profanityFilterWithRegex
+            .containsRestrictedWords(text: "hello 9299999999"))
     }
 }

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -390,16 +390,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         autocompletionView.contentInset = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 0)
         chatBar.setup(autocompletionView, withPrefex: "/")
         setRichMessageKitTheme()
-
-        guard !configuration.restrictedWordsFileName.isEmpty else {
-            return
-        }
-        do {
-            profanityFilter = try ProfanityFilter(
-            fileName: configuration.restrictedWordsFileName)
-        } catch {
-            print("Error while loading restricted words file:", error)
-        }
+        setupProfanityFilter()
     }
 
     override open func viewDidLayoutSubviews() {
@@ -816,6 +807,31 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             default:
                 print("Not available")
             }
+        }
+    }
+
+    private func setupProfanityFilter() {
+        func makeProfanityFilter(
+            withRegexPattern pattern: String,
+            andFileName filename: String) throws -> ProfanityFilter? {
+            switch (pattern, filename) {
+            case ("",""):
+                return nil
+            case (let pattern, ""):
+                return(try ProfanityFilter(restrictedMessageRegex: pattern))
+            case ("", let filename):
+                return(try ProfanityFilter(fileName: filename))
+            case (let pattern, let filename):
+                return(try ProfanityFilter(fileName: filename, restrictedMessageRegex: pattern))
+            }
+        }
+
+        do {
+            profanityFilter = try makeProfanityFilter(
+                withRegexPattern: configuration.restrictedMessageRegexPattern,
+                andFileName: configuration.restrictedWordsFileName)
+        } catch {
+            print("Error while setting up profanity filter: \(error.localizedDescription)")
         }
     }
 

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -106,6 +106,17 @@ public struct ALKConfiguration {
     /// File extension of this file will be txt.
     public var restrictedWordsFileName = ""
 
+    /// The regular expression pattern that will be used to
+    /// match the text that the user is sending. By default, it's empty.
+    ///
+    /// This will be combined with the restricted words config option,
+    /// which means if the text is matched with the restricted words or
+    /// through this pattern, then an alert will be shown.
+    ///
+    /// NOTE: Make sure you verify this pattern before setting
+    /// up here.
+    public var restrictedMessageRegexPattern = ""
+
     /// This will show info option in action sheet
     /// when a profile is tapped in group detail screen.
     /// Clicking on the option will send a notification outside.

--- a/Sources/Utilities/ProfanityFilter.swift
+++ b/Sources/Utilities/ProfanityFilter.swift
@@ -13,14 +13,22 @@ struct ProfanityFilter {
         case fileNotFoundError
         case formattingError
     }
-    let fileName: String
+    let fileName: String?
+    let restrictedMessageRegex: String?
     var restrictedWords = Set<String>()
 
     let bundle: Bundle
 
-    init(fileName: String, bundle: Bundle = .main) throws {
+    private init(
+        fileName: String?,
+        messageRegex: String?,
+        bundle: Bundle) throws {
+
         self.fileName = fileName
+        self.restrictedMessageRegex = messageRegex
         self.bundle = bundle
+
+        guard let fileName = fileName else { return }
         do {
             restrictedWords = try restrictedWords(fileName: fileName)
         } catch {
@@ -50,8 +58,36 @@ struct ProfanityFilter {
         var isPresent = false
         for word in wordsInText {
             isPresent = restrictedWords.contains(word)
-            break
+            if isPresent { return true }
+        }
+
+        // If not present in the restricted words then match the text
+        // against the pattern.
+        if let restrictedMessagePattern = restrictedMessageRegex {
+            let range = NSRange(text.startIndex..<text.endIndex, in: text)
+            do {
+                let regex = try NSRegularExpression(pattern: restrictedMessagePattern, options: [])
+                let matches = regex.numberOfMatches(in: text, options: [], range: range)
+                print("Restricted text matches: \(matches)")
+                if matches > 0 { isPresent = true }
+            } catch {
+                print("Error while matching restricted text: \(error.localizedDescription)")
+            }
         }
         return isPresent
+    }
+}
+
+extension ProfanityFilter {
+    init(fileName: String, bundle: Bundle = .main) throws {
+        try self.init(fileName: fileName, messageRegex: nil, bundle: bundle)
+    }
+
+    init(restrictedMessageRegex: String, bundle: Bundle = .main) throws {
+        try self.init(fileName: nil, messageRegex: restrictedMessageRegex, bundle: bundle)
+    }
+
+    init(fileName: String, restrictedMessageRegex: String, bundle: Bundle = .main) throws {
+        try self.init(fileName: fileName, messageRegex: restrictedMessageRegex, bundle: bundle)
     }
 }


### PR DESCRIPTION
## Summary
Added support for passing regular expression pattern to restrict certain messages.
This can be used in combination with the restricted words configuration or individually.

## Motivation
This was required for restricting messages using a pattern. Just comparing words will not cover a lot of different use cases.

## Testing
Added unit test cases in `ProfanityFilterTests` and, tested in the sample app.