### PR TITLE
[AL-3855] Remove empty lines before sending message #trivial

### DIFF
--- a/Demo/ApplozicSwiftDemo.xcodeproj/project.pbxproj
+++ b/Demo/ApplozicSwiftDemo.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		8B4E9FFF215BC804001FD5F3 /* ALKConversationViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4E9FFE215BC804001FD5F3 /* ALKConversationViewModelMock.swift */; };
 		8B523B432067E1DE001B5989 /* ALMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B523B422067E1DE001B5989 /* ALMessageTests.swift */; };
 		8B68A9B42276DFAB0021638A /* TemplateDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B68A9B32276DFAB0021638A /* TemplateDecoderTests.swift */; };
+		8B7C524823473506008AD91D /* NSAttributedStringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7C524723473506008AD91D /* NSAttributedStringExtensionTests.swift */; };
 		8BA6FAE32089F18700BB1F6F /* ALKGenericListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA6FAE22089F18700BB1F6F /* ALKGenericListTests.swift */; };
 		8BA84180206A5A40004DD252 /* ALKGenericCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA8417F206A5A40004DD252 /* ALKGenericCardTests.swift */; };
 		8BB6ACA82068E982003C3B26 /* ALKConversationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB6ACA72068E982003C3B26 /* ALKConversationViewModelTests.swift */; };
@@ -145,6 +146,7 @@
 		8B4E9FFE215BC804001FD5F3 /* ALKConversationViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKConversationViewModelMock.swift; sourceTree = "<group>"; };
 		8B523B422067E1DE001B5989 /* ALMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALMessageTests.swift; sourceTree = "<group>"; };
 		8B68A9B32276DFAB0021638A /* TemplateDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateDecoderTests.swift; sourceTree = "<group>"; };
+		8B7C524723473506008AD91D /* NSAttributedStringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensionTests.swift; sourceTree = "<group>"; };
 		8BA6FAE22089F18700BB1F6F /* ALKGenericListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKGenericListTests.swift; sourceTree = "<group>"; };
 		8BA8417F206A5A40004DD252 /* ALKGenericCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKGenericCardTests.swift; sourceTree = "<group>"; };
 		8BB6ACA72068E982003C3B26 /* ALKConversationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ALKConversationViewModelTests.swift; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 				8B68A9B32276DFAB0021638A /* TemplateDecoderTests.swift */,
 				8BE8B3A622D4AC100001BDC2 /* ALKChatBarConfigurationTests.swift */,
 				8BCCC96B232B846D00D0EB18 /* MessageMentionTests.swift */,
+				8B7C524723473506008AD91D /* NSAttributedStringExtensionTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -700,6 +703,7 @@
 				8BA84180206A5A40004DD252 /* ALKGenericCardTests.swift in Sources */,
 				1A933D7E21CA2E81004C5191 /* ConversationListTableVCMock.swift in Sources */,
 				8B523B432067E1DE001B5989 /* ALMessageTests.swift in Sources */,
+				8B7C524823473506008AD91D /* NSAttributedStringExtensionTests.swift in Sources */,
 				8BDDEA6F21DA09BE005B22E3 /* ALKConversationListViewControllerMock.swift in Sources */,
 				8BDDEA6B21D9F2EE005B22E3 /* ALKConversationVCMemoryLeakTests.swift in Sources */,
 				1A0B17EF21819FF800B19187 /* ALKConversationViewControllerMock.swift in Sources */,

--- a/Demo/ApplozicSwiftDemoTests/Tests/NSAttributedStringExtensionTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/NSAttributedStringExtensionTests.swift
@@ -1,0 +1,57 @@
+//
+//  NSAttributedStringExtensionTests.swift
+//  ApplozicSwiftDemoTests
+//
+//  Created by Mukesh on 04/10/19.
+//  Copyright © 2019 Applozic. All rights reserved.
+//
+
+import XCTest
+@testable import ApplozicSwift
+
+class NSAttributedStringExtensionTests: XCTestCase {
+
+    let charactersToRemove = CharacterSet.whitespacesAndNewlines
+
+    func testAttributedString_whenTrimmed() {
+        let attributedString1 = NSAttributedString(string: " abc ")
+        XCTAssertEqual(attributedString1.trimmingCharacters(in: charactersToRemove).string, "abc")
+
+        let attributedString2 = NSAttributedString(string: "abc \n ")
+        XCTAssertEqual(attributedString2.trimmingCharacters(in: charactersToRemove).string, "abc")
+
+        let attributedString3 = NSAttributedString(string: " ")
+        XCTAssertEqual(attributedString3.trimmingCharacters(in: charactersToRemove).string, "")
+    }
+
+    func testAttributedStringWithAttributes_whenTrimmed() {
+        let attributedString1 = NSMutableAttributedString(string: "abc \n ")
+        let stringWithAttributes = NSAttributedString(
+            string: "with custom color",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.red])
+        attributedString1.append(stringWithAttributes)
+
+        let expectedAttributedString1 = NSMutableAttributedString(string: "abc \n ")
+        expectedAttributedString1.append(stringWithAttributes)
+        XCTAssertEqual(attributedString1.trimmingCharacters(in: charactersToRemove), expectedAttributedString1)
+
+        let attributedString2 = NSMutableAttributedString(string: "  \n abc")
+        attributedString2.append(stringWithAttributes)
+
+        // Empty lines and spaces in the start should be removed
+        // and attributes shouldn't get affected.
+        let expectedAttributedString2 = NSMutableAttributedString(string: "abc")
+        expectedAttributedString2.append(stringWithAttributes)
+        XCTAssertEqual(attributedString2.trimmingCharacters(in: charactersToRemove), expectedAttributedString2)
+
+        let attributedString3 = NSMutableAttributedString(string: "abc")
+        let stringWithAttributesAndEmptyLines = NSAttributedString(
+            string: "with custom color \n  ",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.red])
+        attributedString3.append(stringWithAttributesAndEmptyLines)
+
+        let expectedAttributedString3 = NSMutableAttributedString(string: "abc")
+        expectedAttributedString3.append(stringWithAttributes)
+        XCTAssertEqual(attributedString3.trimmingCharacters(in: charactersToRemove), expectedAttributedString3)
+    }
+}

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -702,7 +702,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
             switch action {
             case let .sendText(button, message):
-
+                let message = message
+                    .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
                 if message.string.count < 1 {
                     return
                 }

--- a/Sources/Utilities/NSAttributedString+Extension.swift
+++ b/Sources/Utilities/NSAttributedString+Extension.swift
@@ -19,4 +19,29 @@ extension NSAttributedString {
         ns.append(rhs)
         return NSAttributedString(attributedString: ns)
     }
+
+    func trimmingCharacters(in set: CharacterSet) -> NSAttributedString {
+        let modifiedString = NSMutableAttributedString(attributedString: self)
+        modifiedString.trimCharacters(in: set)
+        return NSAttributedString(attributedString: modifiedString)
+    }
+}
+
+extension NSMutableAttributedString {
+    public func trimCharacters(in set: CharacterSet) {
+        var range = (string as NSString).rangeOfCharacter(from: set, options: .anchored)
+
+        // Trim leading characters from character set.
+        while range.location != NSNotFound {
+            replaceCharacters(in: range, with: "")
+            range = (string as NSString).rangeOfCharacter(from: set, options: .anchored)
+        }
+
+        // Trim trailing characters from character set.
+        range = (string as NSString).rangeOfCharacter(from: set, options: [.anchored, .backwards])
+        while range.location != NSNotFound {
+            replaceCharacters(in: range, with: "")
+            range = (string as NSString).rangeOfCharacter(from: set, options: [.anchored, .backwards])
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Fixed an issue where empty lines in the start and end were part of the message being sent. This was introduced in #260. 

## Motivation
Remove empty lines and white space from the start and end of the message string.

## Testing
Added unit test cases for the new trim method on `NSAttributedString`. Tried on sample app by sending a message with only spaces, now it won't be sent.