### PR TITLE
[AL-3852] Add setting for message bubble border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,19 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - [AL-3847] Updated UI for link button and refractored rich messages to use same view for all types of buttons.
 - [AL-3642] Added support for message search.
 - [AL-3853] Added support for navigation bar customization using `UIAppearance`.
-- [AL-3852] Added setting for adding border to message bubble. This setting will only take effect with round bubble and will only work with text messages, audio messages and contact messages. For other messages the setting will have no effect.
+- [AL-3852] Added setting for adding border to message bubble.
+This setting will only take effect with round bubble and will only work with text messages, audio messages and contact messages. For other messages the setting will have no effect.
 Below is the sample code to illustrate how to use this setting:
 ```
         ALKMessageStyle.sentBubble.style = .round
-        ALKMessageStyle.sentBubble.border.color = UIColor.blue.cgColor
+        ALKMessageStyle.sentBubble.border.color = UIColor.blue
         ALKMessageStyle.sentBubble.border.width = 2
 
         ALKMessageStyle.receivedBubble.style = .round
-        ALKMessageStyle.receivedBubble.border.color = UIColor.red.cgColor
+        ALKMessageStyle.receivedBubble.border.color = UIColor.red
         ALKMessageStyle.receivedBubble.border.width = 2
 ```
-- Back button on Chat screen will now just pop. Earlier it will popping to root view controller.
+- Back button on Chat screen will now just pop. Earlier it was going back to the root view controller.
 
 ### Fixes
 - [AL-3862] Fixed a crash where dbMessage was being forcefully unwrapped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,24 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ### Enhancements
 - [AL-3761] Added support for member mention in groups.
 - [AL-3741] Added support for rich message template 11.
-- [AL-3847] Updated UI for link button and refractored rich messages to use same view for all types of buttons. 
+- [AL-3847] Updated UI for link button and refractored rich messages to use same view for all types of buttons.
 - [AL-3642] Added support for message search.
 - [AL-3853] Added support for navigation bar customization using `UIAppearance`.
+- [AL-3852] Added setting for adding border to message bubble. This setting will only take effect with round bubble and will only work with text messages, audio messages and contact messages. For other messages the setting will have no effect.
+Below is the sample code to illustrate how to use this setting:
+```
+        ALKMessageStyle.sentBubble.style = .round
+        ALKMessageStyle.sentBubble.border.color = UIColor.blue.cgColor
+        ALKMessageStyle.sentBubble.border.width = 2
 
+        ALKMessageStyle.receivedBubble.style = .round
+        ALKMessageStyle.receivedBubble.border.color = UIColor.red.cgColor
+        ALKMessageStyle.receivedBubble.border.width = 2
+```
+- Back button on Chat screen will now just pop. Earlier it will popping to root view controller.
+
+### Fixes
+- [AL-3862] Fixed a crash where dbMessage was being forcefully unwrapped.
 
 3.3.0
 ---

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -414,10 +414,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
 
     override func backTapped() {
-        print("back tapped")
         view.endEditing(true)
         viewModel.sendKeyboardDoneTyping()
-        let popVC = navigationController?.popToRootViewController(animated: true)
+        let popVC = navigationController?.popViewController(animated: true)
         if popVC == nil {
             dismiss(animated: true, completion: nil)
         }

--- a/Sources/Utilities/ALKImageView+Extension.swift
+++ b/Sources/Utilities/ALKImageView+Extension.swift
@@ -1,0 +1,41 @@
+//
+//  ALKImageView+Extension.swift
+//  ApplozicSwift
+//
+//  Created by Shivam Pokhriyal on 10/10/19.
+//
+
+import Foundation
+import UIKit
+import Kingfisher
+
+extension ALKImageView {
+
+    func setStyle(_ bubbleStyle: ALKMessageStyle.Bubble, isReceiverSide: Bool) {
+        if bubbleStyle.style == .edge {
+            tintColor = bubbleStyle.color
+            image = imageBubble(for: bubbleStyle.style, isReceiverSide: isReceiverSide, showHangOverImage: false)
+        } else {
+            super.setBubbleStyle(bubbleStyle)
+        }
+    }
+
+    func imageBubble(for _: ALKMessageStyle.BubbleStyle,
+                     isReceiverSide: Bool,
+                     showHangOverImage: Bool) -> UIImage? {
+        var imageTitle = showHangOverImage ? "chat_bubble_red_hover" : "chat_bubble_red"
+        // We can rotate the above image but loading the required
+        // image would be faster and we already have both the images.
+        if isReceiverSide { imageTitle = showHangOverImage ? "chat_bubble_grey_hover" : "chat_bubble_grey" }
+
+        guard let bubbleImage = UIImage(named: imageTitle, in: Bundle.applozic, compatibleWith: nil)
+            else { return nil }
+
+        // This API is from the Kingfisher so instead of directly using
+        // imageFlippedForRightToLeftLayoutDirection() we are using this as it handles
+        // platform availability and future updates for us.
+        let modifier = FlipsForRightToLeftLayoutDirectionImageModifier()
+        return modifier.modify(bubbleImage)
+    }
+
+}

--- a/Sources/Utilities/Message+Style.swift
+++ b/Sources/Utilities/Message+Style.swift
@@ -66,6 +66,12 @@ public enum ALKMessageStyle {
     }
 
     public struct Bubble {
+
+        public struct Border {
+            public var color: CGColor = UIColor.clear.cgColor
+            public var width: CGFloat = 0
+        }
+
         /// Message bubble's background color.
         public var color: UIColor
 
@@ -74,6 +80,10 @@ public enum ALKMessageStyle {
 
         /// BubbleStyle of the message bubble.
         public var style: BubbleStyle
+
+        /// Used to add border to bubble.
+        /// Note: Only works when `BubbleStyle` is `round`
+        public var border: Border = Border()
 
         /// Width padding which will be used for message view's
         /// right and left padding.

--- a/Sources/Utilities/Message+Style.swift
+++ b/Sources/Utilities/Message+Style.swift
@@ -68,7 +68,7 @@ public enum ALKMessageStyle {
     public struct Bubble {
 
         public struct Border {
-            public var color: CGColor = UIColor.clear.cgColor
+            public var color: UIColor = UIColor.clear
             public var width: CGFloat = 0
         }
 
@@ -81,7 +81,7 @@ public enum ALKMessageStyle {
         /// BubbleStyle of the message bubble.
         public var style: BubbleStyle
 
-        /// Used to add border to bubble.
+        /// For setting border to bubble.
         /// Note: Only works when `BubbleStyle` is `round`
         public var border: Border = Border()
 

--- a/Sources/Utilities/UIView+Extension.swift
+++ b/Sources/Utilities/UIView+Extension.swift
@@ -25,7 +25,7 @@ extension UIView {
         layer.cornerRadius = style.cornerRadius
         tintColor = style.color
         backgroundColor = style.color
-        layer.borderColor = style.border.color
+        layer.borderColor = style.border.color.cgColor
         layer.borderWidth = style.border.width
     }
 }

--- a/Sources/Utilities/UIView+Extension.swift
+++ b/Sources/Utilities/UIView+Extension.swift
@@ -20,4 +20,12 @@ extension UIView {
     func constraint(withIdentifier: String) -> NSLayoutConstraint? {
         return constraints.filter { $0.identifier == withIdentifier }.first
     }
+
+    func setBubbleStyle(_ style: ALKMessageStyle.Bubble) {
+        layer.cornerRadius = style.cornerRadius
+        tintColor = style.color
+        backgroundColor = style.color
+        layer.borderColor = style.border.color
+        layer.borderWidth = style.border.width
+    }
 }

--- a/Sources/Views/ALKFriendContactMessageCell.swift
+++ b/Sources/Views/ALKFriendContactMessageCell.swift
@@ -82,9 +82,9 @@ class ALKFriendContactMessageCell: ALKContactMessageBaseCell {
 
     override func setupStyle() {
         super.setupStyle()
-        contactView.setColorIn(
-            text: ALKMessageStyle.receivedMessage.text,
-            background: ALKMessageStyle.receivedBubble.color
+        contactView.setStyle(
+            itemColor: ALKMessageStyle.receivedMessage.text,
+            bubbleStyle: ALKMessageStyle.receivedBubble
         )
     }
 

--- a/Sources/Views/ALKFriendMessageCell.swift
+++ b/Sources/Views/ALKFriendMessageCell.swift
@@ -271,14 +271,7 @@ open class ALKFriendMessageCell: ALKMessageCell {
 
         nameLabel.setStyle(ALKMessageStyle.displayName)
         messageView.setStyle(ALKMessageStyle.receivedMessage)
-        if ALKMessageStyle.receivedBubble.style == .edge {
-            bubbleView.tintColor = ALKMessageStyle.receivedBubble.color
-            bubbleView.image = bubbleViewImage(for: ALKMessageStyle.receivedBubble.style, isReceiverSide: true, showHangOverImage: false)
-        } else {
-            bubbleView.layer.cornerRadius = ALKMessageStyle.receivedBubble.cornerRadius
-            bubbleView.tintColor = ALKMessageStyle.receivedBubble.color
-            bubbleView.backgroundColor = ALKMessageStyle.receivedBubble.color
-        }
+        bubbleView.setStyle(ALKMessageStyle.receivedBubble, isReceiverSide: true)
     }
 
     override func update(viewModel: ALKMessageViewModel) {
@@ -363,14 +356,20 @@ open class ALKFriendMessageCell: ALKMessageCell {
     override func menuWillShow(_ sender: Any) {
         super.menuWillShow(sender)
         if ALKMessageStyle.receivedBubble.style == .edge {
-            bubbleView.image = bubbleViewImage(for: ALKMessageStyle.receivedBubble.style, isReceiverSide: true, showHangOverImage: true)
+            bubbleView.image = bubbleView.imageBubble(
+                for: ALKMessageStyle.receivedBubble.style,
+                isReceiverSide: true,
+                showHangOverImage: true)
         }
     }
 
     override func menuWillHide(_ sender: Any) {
         super.menuWillHide(sender)
         if ALKMessageStyle.receivedBubble.style == .edge {
-            bubbleView.image = bubbleViewImage(for: ALKMessageStyle.receivedBubble.style, isReceiverSide: true, showHangOverImage: false)
+            bubbleView.image = bubbleView.imageBubble(
+                for: ALKMessageStyle.receivedBubble.style,
+                isReceiverSide: true,
+                showHangOverImage: false)
         }
     }
 

--- a/Sources/Views/ALKFriendVoiceCell.swift
+++ b/Sources/Views/ALKFriendVoiceCell.swift
@@ -48,11 +48,8 @@ class ALKFriendVoiceCell: ALKVoiceCell {
             bubbleView.backgroundColor = ALKMessageStyle.receivedBubble.color
             bubbleView.layer.cornerRadius = ALKMessageStyle.receivedBubble.cornerRadius
         } else {
-            soundPlayerView.layer.cornerRadius = ALKMessageStyle.receivedBubble.cornerRadius
-            bubbleView.layer.cornerRadius = ALKMessageStyle.receivedBubble.cornerRadius
-            bubbleView.tintColor = ALKMessageStyle.receivedBubble.color
-            bubbleView.backgroundColor = ALKMessageStyle.receivedBubble.color
-            soundPlayerView.backgroundColor = ALKMessageStyle.receivedBubble.color
+            bubbleView.setBubbleStyle(ALKMessageStyle.receivedBubble)
+            soundPlayerView.setBubbleStyle(ALKMessageStyle.receivedBubble)
         }
     }
 

--- a/Sources/Views/ALKMessageBaseCell.swift
+++ b/Sources/Views/ALKMessageBaseCell.swift
@@ -286,22 +286,6 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel> {
         replyViewAction?()
     }
 
-    func bubbleViewImage(for _: ALKMessageStyle.BubbleStyle, isReceiverSide: Bool = false, showHangOverImage: Bool) -> UIImage? {
-        var imageTitle = showHangOverImage ? "chat_bubble_red_hover" : "chat_bubble_red"
-        // We can rotate the above image but loading the required
-        // image would be faster and we already have both the images.
-        if isReceiverSide { imageTitle = showHangOverImage ? "chat_bubble_grey_hover" : "chat_bubble_grey" }
-
-        guard let bubbleImage = UIImage(named: imageTitle, in: Bundle.applozic, compatibleWith: nil)
-        else { return nil }
-
-        // This API is from the Kingfisher so instead of directly using
-        // imageFlippedForRightToLeftLayoutDirection() we are using this as it handles
-        // platform availability and future updates for us.
-        let modifier = FlipsForRightToLeftLayoutDirectionImageModifier()
-        return modifier.modify(bubbleImage)
-    }
-
     // MARK: - Private helper methods
 
     private class func attributedStringFrom(_ text: String, for id: String) -> NSAttributedString? {

--- a/Sources/Views/ALKMyContactMessageCell.swift
+++ b/Sources/Views/ALKMyContactMessageCell.swift
@@ -67,9 +67,9 @@ class ALKMyContactMessageCell: ALKContactMessageBaseCell {
 
     override func setupStyle() {
         super.setupStyle()
-        contactView.setColorIn(
-            text: ALKMessageStyle.sentMessage.text,
-            background: ALKMessageStyle.sentBubble.color
+        contactView.setStyle(
+            itemColor: ALKMessageStyle.sentMessage.text,
+            bubbleStyle: ALKMessageStyle.sentBubble
         )
     }
 

--- a/Sources/Views/ALKMyMessageCell.swift
+++ b/Sources/Views/ALKMyMessageCell.swift
@@ -222,14 +222,7 @@ open class ALKMyMessageCell: ALKMessageCell {
     open override func setupStyle() {
         super.setupStyle()
         messageView.setStyle(ALKMessageStyle.sentMessage)
-        if ALKMessageStyle.sentBubble.style == .edge {
-            bubbleView.tintColor = ALKMessageStyle.sentBubble.color
-            bubbleView.image = bubbleViewImage(for: ALKMessageStyle.sentBubble.style, isReceiverSide: false, showHangOverImage: false)
-        } else {
-            bubbleView.layer.cornerRadius = ALKMessageStyle.sentBubble.cornerRadius
-            bubbleView.tintColor = ALKMessageStyle.sentBubble.color
-            bubbleView.backgroundColor = ALKMessageStyle.sentBubble.color
-        }
+        bubbleView.setStyle(ALKMessageStyle.sentBubble, isReceiverSide: false)
     }
 
     open override func update(viewModel: ALKMessageViewModel) {
@@ -323,14 +316,20 @@ open class ALKMyMessageCell: ALKMessageCell {
     override func menuWillShow(_ sender: Any) {
         super.menuWillShow(sender)
         if ALKMessageStyle.sentBubble.style == .edge {
-            bubbleView.image = bubbleViewImage(for: ALKMessageStyle.sentBubble.style, isReceiverSide: false, showHangOverImage: true)
+            bubbleView.image = bubbleView.imageBubble(
+                for: ALKMessageStyle.sentBubble.style,
+                isReceiverSide: false,
+                showHangOverImage: true)
         }
     }
 
     override func menuWillHide(_ sender: Any) {
         super.menuWillHide(sender)
         if ALKMessageStyle.sentBubble.style == .edge {
-            bubbleView.image = bubbleViewImage(for: ALKMessageStyle.sentBubble.style, isReceiverSide: false, showHangOverImage: false)
+            bubbleView.image = bubbleView.imageBubble(
+                for: ALKMessageStyle.sentBubble.style,
+                isReceiverSide: false,
+                showHangOverImage: false)
         }
     }
 }

--- a/Sources/Views/ALKMyVoiceCell.swift
+++ b/Sources/Views/ALKMyVoiceCell.swift
@@ -72,11 +72,8 @@ class ALKMyVoiceCell: ALKVoiceCell {
             bubbleView.backgroundColor = ALKMessageStyle.sentBubble.color
             bubbleView.layer.cornerRadius = ALKMessageStyle.sentBubble.cornerRadius
         } else {
-            soundPlayerView.layer.cornerRadius = ALKMessageStyle.sentBubble.cornerRadius
-            bubbleView.layer.cornerRadius = ALKMessageStyle.sentBubble.cornerRadius
-            bubbleView.tintColor = ALKMessageStyle.sentBubble.color
-            bubbleView.backgroundColor = ALKMessageStyle.sentBubble.color
-            soundPlayerView.backgroundColor = ALKMessageStyle.sentBubble.color
+            bubbleView.setBubbleStyle(ALKMessageStyle.sentBubble)
+            soundPlayerView.setBubbleStyle(ALKMessageStyle.sentBubble)
         }
     }
 }

--- a/Sources/Views/ALKPhotoCell.swift
+++ b/Sources/Views/ALKPhotoCell.swift
@@ -377,7 +377,7 @@ class ALKPhotoCell: ALKChatBaseCell<ALKMessageViewModel>,
 
     fileprivate func updateThumbnailPath(_ key: String, filePath: String) {
         let messageKey = ThumbnailIdentifier.removePrefix(from: key)
-        let dbMessage = ALMessageDBService().getMessageByKey("key", value: messageKey) as! DB_Message
+        guard let dbMessage = ALMessageDBService().getMessageByKey("key", value: messageKey) as? DB_Message else { return }
         dbMessage.fileMetaInfo.thumbnailFilePath = filePath
 
         let alHandler = ALDBHandler.sharedInstance()

--- a/Sources/Views/ContactView.swift
+++ b/Sources/Views/ContactView.swift
@@ -81,10 +81,10 @@ class ContactView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setColorIn(text: UIColor, background: UIColor) {
-        contactName.textColor = text
-        contactSaveIcon.tintColor = text
-        backgroundColor = background
+    func setStyle(itemColor: UIColor, bubbleStyle: ALKMessageStyle.Bubble) {
+        contactName.textColor = itemColor
+        contactSaveIcon.tintColor = itemColor
+        setBubbleStyle(bubbleStyle)
     }
 
     func update(contactModel: ContactModel) {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
This PR will: 
1. replace popToRootViewController with popViewController when back is pressed in chat screen.
2. Fix force unwrapping of dbMessage
3. add a setting to add border color and border radius to message bubble. It will only work with round message bubbles. 
This setting will be applied to :: 
1. Text Messages
2. Audio Messages
3. Contact Messages. 

This setting won't work on: 
1. Rich messages (Might add support later).
2. Image message.
3. Video messages.
4. Location message.

This is how you can use it:: 
```
        ALKMessageStyle.sentBubble.style = .round
        ALKMessageStyle.sentBubble.border.color = UIColor.blue
        ALKMessageStyle.sentBubble.border.width = 2

        ALKMessageStyle.receivedBubble.style = .round
        ALKMessageStyle.receivedBubble.border.color = UIColor.red
        ALKMessageStyle.receivedBubble.border.width = 2
```

By Default, there will be no border: 
borderWidth = 0 and borderColor = clear.

Below is how the UI will look using above settings.
![This is how the UI will look using above settings.](https://user-images.githubusercontent.com/29516995/66633307-28457b80-ec28-11e9-8f64-03a5c543e21f.png)
