### PR TITLE
[AL-3853] Use UIAppearance for navigation bar customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - [AL-3761] Added support for member mention in groups.
 - [AL-3741] Added support for rich message template 11.
 - [AL-3847] Updated UI for link button and refractored rich messages to use same view for all types of buttons. 
-- [AL-AL-3642] Added support for message search.
+- [AL-3642] Added support for message search.
+- [AL-3853] Added support for navigation bar customization using `UIAppearance`.
+
 
 3.3.0
 ---

--- a/Demo/ApplozicSwiftDemo/AppDelegate.swift
+++ b/Demo/ApplozicSwiftDemo/AppDelegate.swift
@@ -26,6 +26,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         BuddyBuildSDK.setup()
 
+        let navigationBarProxy = UINavigationBar.appearance(whenContainedInInstancesOf: [ALKBaseNavigationViewController.self])
+        navigationBarProxy.barTintColor
+            = UIColor(red:0.93, green:0.94, blue:0.95, alpha:1.0) // light nav blue
+        navigationBarProxy.isTranslucent = false
 
         /// Use this for Customizing notification.
         /// - NOTE:

--- a/Sources/Controllers/ALKBaseNavigationController.swift
+++ b/Sources/Controllers/ALKBaseNavigationController.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+
 public class ALKBaseNavigationViewController: UINavigationController {
     static var statusBarStyle: UIStatusBarStyle = .lightContent
 
@@ -14,14 +15,26 @@ public class ALKBaseNavigationViewController: UINavigationController {
         super.viewDidLoad()
 
         setNeedsStatusBarAppearanceUpdate()
-    }
-
-    public override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+        setupAppearance()
     }
 
     public override var preferredStatusBarStyle: UIStatusBarStyle {
         return ALKBaseNavigationViewController.statusBarStyle
+    }
+
+    private func setupAppearance() {
+        let navigationBarProxy = UINavigationBar.appearance(whenContainedInInstancesOf: [ALKBaseNavigationViewController.self])
+        navigationBarProxy.tintColor = navigationBarProxy.tintColor ?? UIColor.navigationTextOceanBlue()
+        navigationBarProxy.titleTextAttributes =
+            navigationBarProxy.titleTextAttributes ?? [NSAttributedString.Key.foregroundColor: UIColor.black]
+
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = navigationBarProxy.barTintColor
+            appearance.titleTextAttributes = navigationBarProxy.titleTextAttributes ?? [:]
+            navigationBarProxy.scrollEdgeAppearance = appearance
+            navigationBarProxy.compactAppearance = appearance
+            navigationBarProxy.standardAppearance = appearance
+        }
     }
 }

--- a/Sources/Controllers/ALKBaseViewController.swift
+++ b/Sources/Controllers/ALKBaseViewController.swift
@@ -26,17 +26,13 @@ open class ALKBaseViewController: UIViewController, ALKConfigurable {
 
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.navigationBar.barTintColor = configuration.navigationBarBackgroundColor
-        navigationController?.navigationBar.tintColor = configuration.navigationBarItemColor
 
-        navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: configuration.navigationBarTitleColor]
-
-        navigationController?.navigationBar.isTranslucent = false
         if navigationController?.viewControllers.first != self {
             var backImage = UIImage(named: "icon_back", in: Bundle.applozic, compatibleWith: nil)
             backImage = backImage?.imageFlippedForRightToLeftLayoutDirection()
             navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .plain, target: self, action: #selector(backTapped))
         }
+
         if configuration.hideNavigationBarBottomLine {
             navigationController?.navigationBar.hideBottomHairline()
         }

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -229,15 +229,6 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
         setupNavigationRightButtons()
         setupBackButton()
         title = localizedString(forKey: "ConversationListVCTitle", withDefaultValue: SystemMessage.ChatList.title, fileName: localizedStringFileName)
-        #if DEVELOPMENT
-            let indicator = UIActivityIndicatorView(activityIndicatorStyle: .white)
-            indicator.frame = CGRect(x: 0, y: 0, width: 44, height: 44)
-            indicator.hidesWhenStopped = true
-            indicator.stopAnimating()
-            let indicatorButton = UIBarButtonItem(customView: indicator)
-
-            navigationItem.leftBarButtonItem = indicatorButton
-        #endif
 
         add(conversationListTableViewController)
         conversationListTableViewController.view.frame = view.bounds

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -26,18 +26,6 @@ public struct ALKConfiguration {
     /// navigation bar is visible. Default value is true.
     public var hideNavigationBarBottomLine = true
 
-    /// Navigation bar's background color. It will be used in all the
-    /// ViewControllers where navigation bar is visible.
-    public var navigationBarBackgroundColor = UIColor.navigationOceanBlue()
-
-    /// Navigation bar's tint color. It will be used in all the
-    /// ViewControllers where navigation bar is visible.
-    public var navigationBarItemColor = UIColor.navigationTextOceanBlue()
-
-    /// Navigation bar's title color. It will be used in all the
-    /// ViewControllers where navigation bar is visible.
-    public var navigationBarTitleColor = UIColor.black
-
     /// ChatBar's bottom view color. This is the view which contains
     /// all the attachment and other options.
     public var chatBarAttachmentViewBackgroundColor = UIColor.background(.grayEF)
@@ -197,6 +185,37 @@ public struct ALKConfiguration {
 
     /// Use this to configure channel detail view like changing member name label color, title font etc.
     public var channelDetail = ALKChannelDetailViewConfiguration()
+
+    /// Navigation bar's background color. It will be used in all the
+    /// ViewControllers where navigation bar is visible.
+    @available(*, deprecated, message: "Use UIAppearance for customization.")
+    public var navigationBarBackgroundColor = UIColor.navigationOceanBlue() {
+        didSet {
+            let navigationBarProxy = UINavigationBar.appearance(whenContainedInInstancesOf: [ALKBaseNavigationViewController.self])
+            navigationBarProxy.barTintColor = navigationBarBackgroundColor
+        }
+    }
+
+    /// Navigation bar's tint color. It will be used in all the
+    /// ViewControllers where navigation bar is visible.
+    @available(*, deprecated, message: "Use UIAppearance for customization.")
+    public var navigationBarItemColor = UIColor.navigationTextOceanBlue() {
+        didSet {
+            let navigationBarProxy = UINavigationBar.appearance(whenContainedInInstancesOf: [ALKBaseNavigationViewController.self])
+            navigationBarProxy.tintColor = navigationBarItemColor
+        }
+    }
+
+    /// Navigation bar's title color. It will be used in all the
+    /// ViewControllers where navigation bar is visible.
+    @available(*, deprecated, message: "Use UIAppearance for customization.")
+    public var navigationBarTitleColor = UIColor.black {
+        didSet {
+            let navigationBarProxy = UINavigationBar.appearance(whenContainedInInstancesOf: [ALKBaseNavigationViewController.self])
+            navigationBarProxy.titleTextAttributes =
+                [NSAttributedString.Key.foregroundColor: navigationBarTitleColor]
+        }
+    }
 
     public init() {}
 }


### PR DESCRIPTION
## Summary
This PR will add support for customizing `UINavigationBar` using navigation bar proxy. Now navigation bar properties can be changed from outside using `UIAppearance`. Deprecated navigation bar related configuration properties, but they'll still work for now.

## Motivation
We were hard coding some navigation bar properties which made it difficult to customize. And adding configuration properties for theme changes is not a good idea.