### PR TITLE
Update MGSwipeTableCell for iOS 13 and update swipe buttons after mute

### DIFF
--- a/ApplozicSwift.podspec
+++ b/ApplozicSwift.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     complete.source_files = 'Sources/**/*.swift'
     complete.resources = 'Sources/**/*{lproj,storyboard,xib,xcassets,json}'
     complete.dependency 'Kingfisher', '~> 5.7.0'
-    complete.dependency 'MGSwipeTableCell', '~> 1.6.8'
+    complete.dependency 'MGSwipeTableCell', '~> 1.6.9'
     complete.dependency 'Applozic', '~> 6.16.0'
     complete.dependency 'ApplozicSwift/RichMessageKit'
   end

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - Applozic (~> 6.16.0)
     - ApplozicSwift/RichMessageKit
     - Kingfisher (~> 5.7.0)
-    - MGSwipeTableCell (~> 1.6.8)
+    - MGSwipeTableCell (~> 1.6.9)
   - ApplozicSwift/RichMessageKit (3.3.0)
   - iOSSnapshotTestCase (6.1.0):
     - iOSSnapshotTestCase/SwiftSupport (= 6.1.0)
@@ -15,7 +15,7 @@ PODS:
   - iOSSnapshotTestCase/SwiftSupport (6.1.0):
     - iOSSnapshotTestCase/Core
   - Kingfisher (5.7.1)
-  - MGSwipeTableCell (1.6.8)
+  - MGSwipeTableCell (1.6.9)
   - Nimble (8.0.2)
   - Nimble-Snapshots (8.0.0):
     - Nimble-Snapshots/Core (= 8.0.0)
@@ -56,10 +56,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Applozic: e60d7863e31f8a5afefcb72229f6540fc45de4c3
-  ApplozicSwift: 875e800a29ab99cdbaf16923b8c06c868ac8262d
+  ApplozicSwift: be831df513bc7a000e0b470a2beb9894d4c63fa1
   iOSSnapshotTestCase: 30d540b0c8feb9d7f8ff97acc25a3804b48ee264
   Kingfisher: 176d377ad339113c99ad4980cbae687f807e20fe
-  MGSwipeTableCell: dc4eca3212ed38a563b27d6aa7b3c01ce656c1e2
+  MGSwipeTableCell: 17349a8b56c81245bd77671251eb8aa9d486d46b
   Nimble: 622629381bda1dd5678162f21f1368cec7cbba60
   Nimble-Snapshots: 8ec63f41ce6c7229a17be9a64edbc123b181f75b
   Quick: 4be43f6634acfa727dd106bdf3929ce125ffa79d

--- a/Sources/Controllers/ALKConversationListTableViewController.swift
+++ b/Sources/Controllers/ALKConversationListTableViewController.swift
@@ -644,23 +644,17 @@ extension ALKConversationListTableViewController: ALKChatCellDelegate {
         // Start activity indicator
         self.activityIndicator.startAnimating()
 
-        viewModel.sendUnmuteRequestFor(message: conversation, withCompletion: { success in
-
+        viewModel.sendUnmuteRequestFor(message: conversation, withCompletion: { [weak self] success in
+            guard let weakSelf = self else { return }
             // Stop activity indicator
-            self.activityIndicator.stopAnimating()
+            weakSelf.activityIndicator.stopAnimating()
 
             guard success == true else {
                 return
             }
 
-            self.delegate?.muteNotification(conversation: conversation, isMuted: false)
-            // Update UI
-            if let cell = self.tableView.cellForRow(at: atIndexPath) as? ALKChatCell {
-                guard let chat = self.searchActive ? self.searchFilteredChat[atIndexPath.row] as? ALMessage : self.viewModel.chatFor(indexPath: atIndexPath) as? ALMessage else {
-                    return
-                }
-                cell.update(viewModel: chat, identity: nil, disableSwipe: self.configuration.disableSwipeInChatCell)
-            }
+            weakSelf.delegate?.muteNotification(conversation: conversation, isMuted: false)
+            weakSelf.tableView.reloadRows(at: [atIndexPath], with: .none)
         })
     }
 
@@ -713,24 +707,18 @@ extension ALKConversationListTableViewController: Muteable {
 
         let time = (Int64(Date().timeIntervalSince1970) * 1000) + forTime
 
-        self.viewModel.sendMuteRequestFor(message: conversation, tillTime: NSNumber(value: time)) { success in
-
+        self.viewModel.sendMuteRequestFor(message: conversation, tillTime: NSNumber(value: time)) { [weak self] success in
+            guard let weakSelf = self else { return }
             // Stop activity indicator
-            self.activityIndicator.stopAnimating()
+            weakSelf.activityIndicator.stopAnimating()
 
             // Update indexPath
             guard success == true else {
                 return
             }
 
-            self.delegate?.muteNotification(conversation: conversation, isMuted: true)
-
-            if let cell = self.tableView.cellForRow(at: atIndexPath) as? ALKChatCell {
-                guard let chat = self.searchActive ? self.searchFilteredChat[atIndexPath.row] as? ALMessage : self.viewModel.chatFor(indexPath: atIndexPath) as? ALMessage else {
-                    return
-                }
-                cell.update(viewModel: chat, identity: nil, disableSwipe: self.configuration.disableSwipeInChatCell)
-            }
+            weakSelf.delegate?.muteNotification(conversation: conversation, isMuted: true)
+            weakSelf.tableView.reloadRows(at: [atIndexPath], with: .none)
         }
     }
 }

--- a/Sources/Controllers/ALKConversationListTableViewController.swift
+++ b/Sources/Controllers/ALKConversationListTableViewController.swift
@@ -654,7 +654,9 @@ extension ALKConversationListTableViewController: ALKChatCellDelegate {
             }
 
             weakSelf.delegate?.muteNotification(conversation: conversation, isMuted: false)
-            weakSelf.tableView.reloadRows(at: [atIndexPath], with: .none)
+            if weakSelf.tableView.isValid(indexPath: atIndexPath) {
+                weakSelf.tableView.reloadRows(at: [atIndexPath], with: .none)
+            }
         })
     }
 
@@ -718,7 +720,9 @@ extension ALKConversationListTableViewController: Muteable {
             }
 
             weakSelf.delegate?.muteNotification(conversation: conversation, isMuted: true)
-            weakSelf.tableView.reloadRows(at: [atIndexPath], with: .none)
+            if weakSelf.tableView.isValid(indexPath: atIndexPath) {
+                weakSelf.tableView.reloadRows(at: [atIndexPath], with: .none)
+            }
         }
     }
 }

--- a/Sources/Utilities/UITableView+Extension.swift
+++ b/Sources/Utilities/UITableView+Extension.swift
@@ -53,4 +53,8 @@ extension UITableView {
         guard let indexes = self.indexPathsForVisibleRows else { return false }
         return indexes.contains { $0.section == section && $0.row == row }
     }
+
+    func isValid(indexPath: IndexPath) -> Bool {
+        return indexPath.section < numberOfSections && indexPath.row < numberOfRows(inSection: indexPath.section)
+    }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Update MGSwipeTableCell for iOS 13 and reload rows once mute or unmute button is tapped.

## Motivation
Even after conversation is muted the swipe button wasn't updating. 