### PR TITLE
Fix push notification issue in search controller #trivial

### DIFF
--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -29,7 +29,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
 
     var searchController: UISearchController!
     var searchBar: CustomSearchBar!
-    lazy var resultVC = SearchResultViewController(configuration: configuration)
+    lazy var resultVC = ALKSearchResultViewController(configuration: configuration)
 
     var dbService = ALMessageDBService()
     var viewModel = ALKConversationListViewModel()

--- a/Sources/Controllers/ALKSearchResultViewController.swift
+++ b/Sources/Controllers/ALKSearchResultViewController.swift
@@ -9,7 +9,7 @@
 import Applozic
 import UIKit
 
-class SearchResultViewController: UIViewController {
+class ALKSearchResultViewController: UIViewController {
     fileprivate let activityIndicator = UIActivityIndicatorView(style: UIActivityIndicatorView.Style.gray)
 
     let viewModel = SearchResultViewModel()
@@ -75,7 +75,7 @@ class SearchResultViewController: UIViewController {
     }
 }
 
-extension SearchResultViewController: ALKConversationListTableViewDelegate {
+extension ALKSearchResultViewController: ALKConversationListTableViewDelegate {
     func muteNotification(conversation _: ALMessage, isMuted _: Bool) {}
 
     func userBlockNotification(userId _: String, isBlocked _: Bool) {}

--- a/Sources/Utilities/ALKPushNotificationHandler.swift
+++ b/Sources/Utilities/ALKPushNotificationHandler.swift
@@ -11,33 +11,7 @@ import Foundation
 
 public class ALKPushNotificationHandler: Localizable {
     public static let shared = ALKPushNotificationHandler()
-    var navVC: UINavigationController?
-
-    var contactId: String?
-    var groupId: NSNumber?
-    var conversationId: NSNumber?
-    var title: String = ""
     var configuration: ALKConfiguration!
-
-    private var alContact: ALContact? {
-        let alContactDbService = ALContactDBService()
-        guard let alContact = alContactDbService.loadContact(byKey: "userId", value: self.contactId) else {
-            return nil
-        }
-        return alContact
-    }
-
-    private var alChannel: ALChannel? {
-        let alChannelService = ALChannelService()
-
-        // TODO: This is a workaround as other method uses closure.
-        // Later replace this with:
-        // alChannelService.getChannelInformation(, orClientChannelKey: , withCompletion: )
-        guard let alChannel = alChannelService.getChannelByKey(self.groupId) else {
-            return nil
-        }
-        return alChannel
-    }
 
     public func dataConnectionNotificationHandlerWith(_ configuration: ALKConfiguration) {
         self.configuration = configuration
@@ -45,72 +19,44 @@ public class ALKPushNotificationHandler: Localizable {
         // No need to add removeObserver() as it is present in pushAssist.
         NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "showNotificationAndLaunchChat"), object: nil, queue: nil, using: { [weak self] notification in
             print("launch chat push notification received")
-            self?.contactId = nil
-            self?.groupId = nil
-            self?.title = ""
-            self?.conversationId = nil
-            // Todo: Handle group
-
-            guard let weakSelf = self, let object = notification.object as? String else { return }
-            let components = object.components(separatedBy: ":")
-
-            let noNameMessage = weakSelf.localizedString(forKey: "NoNameMessage", withDefaultValue: SystemMessage.NoData.NoName, fileName: configuration.localizedStringFileName)
-
-            if components.count > 2 {
-                guard let componentElement = Int(components[1]) else { return }
-                let id = NSNumber(integerLiteral: componentElement)
-                weakSelf.groupId = id
-                guard let alChannel = weakSelf.alChannel, let name = alChannel.name else { return }
-                weakSelf.title = name
-            } else if components.count == 2 {
-                guard let conversationComponent = Int(components[1]) else { return }
-                weakSelf.conversationId = NSNumber(integerLiteral: conversationComponent)
-                weakSelf.contactId = components[0]
-                guard let alContact = weakSelf.alContact else { return }
-                weakSelf.title = alContact.getDisplayName() ?? noNameMessage
-            } else {
-                weakSelf.contactId = object
-                guard let alContact = weakSelf.alContact else { return }
-                let displayName = alContact.getDisplayName() ?? noNameMessage
-                weakSelf.title = displayName
-            }
+            let (notifData, msg) = NotificationHelper().notificationInfo(notification)
+            guard
+                let weakSelf = self,
+                let notificationData = notifData,
+                let message = msg
+            else { return }
 
             guard let userInfo = notification.userInfo as? [String: Any], let state = userInfo["updateUI"] as? NSNumber else { return }
 
             switch state {
             case NSNumber(value: APP_STATE_ACTIVE.rawValue):
-                guard let userInfo = notification.userInfo, let alertValue = userInfo["alertValue"] as? String else {
-                    return
-                }
+                guard !NotificationHelper().isNotificationForActiveThread(notificationData) else { return }
                 // TODO: FIX HERE. USE conversationId also.
-                ALUtilityClass.thirdDisplayNotificationTS(alertValue, andForContactId: weakSelf.contactId, withGroupId: weakSelf.groupId, completionHandler: {
+                ALUtilityClass.thirdDisplayNotificationTS(
+                    message,
+                    andForContactId: notificationData.userId,
+                    withGroupId: notificationData.groupId,
+                    completionHandler: {
                     _ in
-                    weakSelf.notificationTapped(userId: weakSelf.contactId, groupId: weakSelf.groupId)
-
+                        weakSelf.launchIndividualChatWith(notificationData: notificationData)
                 })
             default:
-                weakSelf.launchIndividualChatWith(userId: weakSelf.contactId, groupId: weakSelf.groupId)
+                weakSelf.launchIndividualChatWith(notificationData: notificationData)
             }
         })
     }
 
-    func launchIndividualChatWith(userId: String?, groupId: NSNumber?) {
-        NSLog("Called via notification and user id is: ", userId ?? "Not Present")
-
-        let messagesVC = ALKConversationListViewController(configuration: configuration)
-        messagesVC.contactId = userId
-        messagesVC.channelKey = groupId
-        messagesVC.conversationId = conversationId
-
-        let pushAssistant = ALPushAssist()
-        let topVC = pushAssistant.topViewController
-        let nav = ALKBaseNavigationViewController(rootViewController: messagesVC)
-        navVC?.modalTransitionStyle = .crossDissolve
-        navVC?.modalPresentationStyle = .fullScreen
+    func launchIndividualChatWith(notificationData: NotificationHelper.NotificationData) {
+        guard !NotificationHelper().isApplozicVCAtTop() else {
+            NotificationHelper().handleNotificationTap(notificationData)
+            return
+        }
+        let topVC = ALPushAssist().topViewController
+        let listVC = NotificationHelper().getConversationVCToLaunch(notification: notificationData, configuration: configuration)
+        let nav = ALKBaseNavigationViewController(rootViewController: listVC)
+        nav.modalTransitionStyle = .crossDissolve
+        nav.modalPresentationStyle = .fullScreen
         topVC?.present(nav, animated: true, completion: nil)
     }
 
-    func notificationTapped(userId: String?, groupId: NSNumber?) {
-        launchIndividualChatWith(userId: userId, groupId: groupId)
-    }
 }

--- a/Sources/Utilities/NotificationHelper.swift
+++ b/Sources/Utilities/NotificationHelper.swift
@@ -138,6 +138,10 @@ public class NotificationHelper {
         case _ where topVCName.hasPrefix("ALK"):
             return true
         default:
+            if let searchVC = topVC as? UISearchController,
+                searchVC.searchResultsController as? ALKSearchResultViewController != nil {
+                return true
+            }
             return false
         }
     }
@@ -156,6 +160,11 @@ public class NotificationHelper {
             print("ConversationViewController on top")
             refreshConversation(vc, with: notification)
         default:
+            if let searchVC = topVC as? UISearchController,
+                let vc = searchVC.presentingViewController as? ALKConversationListViewController {
+                openConversationFromListVC(vc, notification: notification)
+                return
+            }
             print("Some other view controller need to find chat vc")
             findChatVC(notification)
         }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
When search is enabled, then on tapping on notification it will push a new list controller instance. 
Now, on tap of notification chat screen will open directly and on back press, the search controller will be present.
This will also resolve typing indicator issue where typing indicator was coming for wrong conversation after tapping on notification