### PR TITLE
Update viewmodel with downloaded filepath #trivial

### DIFF
--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -484,6 +484,15 @@ open class ALKConversationViewModel: NSObject, Localizable {
             task.identifier = message.identifier
             task.totalBytesExpectedToDownload = message.size
             httpManager.downloadAttachment(task: task)
+            httpManager.downloadCompleted = { [weak self] task in
+                guard let weakSelf = self, let identifier = task.identifier else { return }
+                var msg = weakSelf.messageForRow(identifier: identifier)
+                if ThumbnailIdentifier.hasPrefix(in: identifier) {
+                    msg?.fileMetaInfo?.thumbnailFilePath = task.filePath
+                } else {
+                    msg?.filePath = task.filePath
+                }
+            }
         }
     }
 

--- a/Sources/Views/ALKPhotoCell.swift
+++ b/Sources/Views/ALKPhotoCell.swift
@@ -316,7 +316,6 @@ class ALKPhotoCell: ALKChatBaseCell<ALKMessageViewModel>,
             if activityIndicator.isAnimating {
                 activityIndicator.stopAnimating()
             }
-            viewModel?.filePath = filePath
             let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             let path = docDirPath.appendingPathComponent(filePath)
             setPhotoViewImageFromFileURL(path)

--- a/Sources/Views/ALKVideoCell.swift
+++ b/Sources/Views/ALKVideoCell.swift
@@ -265,7 +265,6 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
             uploadButton.isHidden = true
             downloadButton.isHidden = true
             progressView.isHidden = true
-            viewModel?.filePath = filePath
             playButton.isHidden = false
             let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             let path = docDirPath.appendingPathComponent(filePath)


### PR DESCRIPTION
Earlier in case of contact filepath wasn't updated in the viewmodel so while scrolling it was downloing the contact again