### PR TITLE
[AL-3887] AutoComplete: Change access-level and update setup #trivial

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -32,10 +32,14 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     public var individualLaunch = true
 
     public lazy var chatBar = ALKChatBar(frame: CGRect.zero, configuration: self.configuration)
-    public lazy var autocompleteManager = AutoCompleteManager(
-        textView: chatBar.textView,
-        tableview: autocompletionView
-    )
+    public lazy var autocompleteManager: AutoCompleteManager = {
+        let manager = AutoCompleteManager(
+            textView: chatBar.textView,
+            tableview: autocompletionView
+        )
+        manager.autocompletionDelegate = self
+        return manager
+    }()
 
     public let autocompletionView: UITableView = {
         let tableview = UITableView(frame: CGRect.zero, style: .plain)
@@ -43,6 +47,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         tableview.estimatedRowHeight = 50
         tableview.rowHeight = UITableView.automaticDimension
         tableview.separatorStyle = .none
+        tableview.contentInset = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 0)
         return tableview
     }()
 
@@ -438,7 +443,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         prepareTable()
         prepareMoreBar()
         prepareChatBar()
-        setupAutoComplete()
+        setupMemberMention()
         replyMessageView.closeButtonTapped = { [weak self] _ in
             self?.hideReplyMessageView()
         }
@@ -862,9 +867,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         }
     }
 
-    private func setupAutoComplete() {
-        autocompletionView.contentInset = UIEdgeInsets(top: 0, left: -5, bottom: 0, right: 0)
-        autocompleteManager.autocompletionDelegate = self
+    private func setupMemberMention() {
         if configuration.isMemberMentionEnabled {
             autocompleteManager.registerPrefix(
                 prefix: MessageMention.Prefix,

--- a/Sources/Models/AutoCompleteItem.swift
+++ b/Sources/Models/AutoCompleteItem.swift
@@ -8,16 +8,18 @@
 import Foundation
 
 public struct AutoCompleteItem {
-    var key: String
-    var content: String
-    var displayImageURL: URL?
-
-    /// A key used for referencing which substrings were autocompletes
-    static let attributesKey = NSAttributedString.Key("com.applozicswift.autocompletekey")
+    public let key: String
+    public let content: String
+    public let displayImageURL: URL?
 
     public init(key: String, content: String, displayImageURL: URL? = nil) {
         self.key = key
         self.content = content
         self.displayImageURL = displayImageURL
     }
+}
+
+extension AutoCompleteItem {
+    /// A key used for referencing which substrings were autocompletes
+    static public let attributesKey = NSAttributedString.Key("com.applozicswift.autocompletekey")
 }


### PR DESCRIPTION
## Summary
- Changed access level of `AutoCompleteManager`'s properties to read the data from outside. 
- Now `autocompleteManager`'s delegate in `ALKConversationViewController` will be set at the creation time, which means the delegate will only be set if the manager is used.