### PR TITLE
[CM-25] CardTemplate: Send a message on button action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Also see the [releases](https://github.com/AppLozic/ApplozicSwift/releases) on Github.
 
+4.0.1(Upcoming release)
+---
+### Fixes
+
+- Fixed an issue where button's title was sent as a message in card template.
+
 4.0.0
 ---
 ### Enhancements

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1245,7 +1245,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             dict["requestType"] = payload.requestType
             submitButtonSelected(metadata: dict, text: payload.text ?? "")
         case CardTemplateActionType.quickReply.rawValue:
-            let text = payload.title ?? buttons[tag].name
+            let text = buttons[tag].action?.payload?.message ?? buttons[tag].name
             sendQuickReply(text, metadata: nil)
         default:
             /// Action not defined. Post notification outside.


### PR DESCRIPTION
## Summary
In case of card template, button's `message` property will be used to send a message.

## Motivation
As payload's title is not present, button's name was sent as a message which is not correct.

## Testing
Tried a card template in the sample app, it's working now.