### PR TITLE
[CM-135] Call app info API to get the package details after suspension screen is shown

### DIFF
--- a/ApplozicSwift.podspec
+++ b/ApplozicSwift.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     complete.resources = 'Sources/**/*{lproj,storyboard,xib,xcassets,json}'
     complete.dependency 'Kingfisher', '~> 5.13.0'
     complete.dependency 'MGSwipeTableCell', '~> 1.6.11'
-    complete.dependency 'Applozic', '~> 7.0.0'
+    complete.dependency 'Applozic', '~> 7.1.0'
     complete.dependency 'ApplozicSwift/RichMessageKit'
   end
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ## [Unreleased]
 
+### Enhancements
+- Added account update status sync.
+
 ## [5.0.0] - 2020-02-14
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ## [Unreleased]
 
 ### Enhancements
-- Added account update status sync.
+- Added support for syncing package details when a suspension screen is shown.
 
 ## [5.0.0] - 2020-02-14
 

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Applozic (7.0.0):
+  - Applozic (7.1.0):
     - SDWebImage (~> 5.1.0)
   - ApplozicSwift (5.0.0):
     - ApplozicSwift/Complete (= 5.0.0)
   - ApplozicSwift/Complete (5.0.0):
-    - Applozic (~> 7.0.0)
+    - Applozic (~> 7.1.0)
     - ApplozicSwift/RichMessageKit
     - Kingfisher (~> 5.13.0)
     - MGSwipeTableCell (~> 1.6.11)
@@ -14,9 +14,9 @@ PODS:
   - iOSSnapshotTestCase/Core (6.2.0)
   - iOSSnapshotTestCase/SwiftSupport (6.2.0):
     - iOSSnapshotTestCase/Core
-  - Kingfisher (5.13.0):
-    - Kingfisher/Core (= 5.13.0)
-  - Kingfisher/Core (5.13.0)
+  - Kingfisher (5.13.1):
+    - Kingfisher/Core (= 5.13.1)
+  - Kingfisher/Core (5.13.1)
   - MGSwipeTableCell (1.6.11)
   - Nimble (8.0.5)
   - Nimble-Snapshots (8.1.1):
@@ -28,8 +28,8 @@ PODS:
   - SDWebImage (5.1.1):
     - SDWebImage/Core (= 5.1.1)
   - SDWebImage/Core (5.1.1)
-  - SwiftFormat/CLI (0.44.0)
-  - SwiftLint (0.38.2)
+  - SwiftFormat/CLI (0.44.2)
+  - SwiftLint (0.39.1)
 
 DEPENDENCIES:
   - ApplozicSwift (from `../ApplozicSwift.podspec`)
@@ -57,17 +57,17 @@ EXTERNAL SOURCES:
     :path: "../ApplozicSwift.podspec"
 
 SPEC CHECKSUMS:
-  Applozic: 56b5e70268a29478e8cac30df6490b0a9251fd20
-  ApplozicSwift: b81035777b58a235c6ad599e2fb0ae043c3cca29
+  Applozic: d4c79ed0d8a14fbf48d46fba4f6ee1729c64d264
+  ApplozicSwift: 400658ca04f76acd7231a58d432cea3c32a4c182
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
-  Kingfisher: 0d334cada987fcddbe9b5cec516406e1ee9d4748
+  Kingfisher: f33a848445e33c543620812158dc5d47f6bf90df
   MGSwipeTableCell: b804e4e450dee439c42250be90bd50458bf67fce
   Nimble: 4ab1aeb9b45553c75b9687196b0fa0713170a332
   Nimble-Snapshots: 5058fb9b459e64371f54a0f8d9dde6f33db490a0
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
   SDWebImage: 96d7f03415ccb28d299d765f93557ff8a617abd8
-  SwiftFormat: 180a4d17bcfa2c9f61b202dac7dddd2087ff920a
-  SwiftLint: 8f5d2f903e1c9bcbc832fd16771e80a263ac6cbb
+  SwiftFormat: 53968b5cc5d466727e796f789fa9be6c38da34cb
+  SwiftLint: 55e96a4a4d537d4a3156859fc1c54bd24851a046
 
 PODFILE CHECKSUM: 37b1748ae38c7d600b4859d10af77ebc84042008
 

--- a/Sources/Controllers/ALKAccountSuspensionController.swift
+++ b/Sources/Controllers/ALKAccountSuspensionController.swift
@@ -5,6 +5,7 @@
 //  Created by Mukesh Thawani on 05/06/18.
 //
 
+import Applozic
 import UIKit
 
 public class ALKAccountSuspensionController: UIViewController {
@@ -17,7 +18,11 @@ public class ALKAccountSuspensionController: UIViewController {
     }
 
     @objc func closeButtonAction(_: UIButton) {
-        closePressed?()
+        let topVC = ALPushAssist().topViewController
+        let vc = topVC?.presentingViewController
+        dismiss(animated: true) {
+            _ = vc?.navigationController?.popToRootViewController(animated: true)
+        }
     }
 
     private func setupViews() {

--- a/Sources/Controllers/ALKAccountSuspensionController.swift
+++ b/Sources/Controllers/ALKAccountSuspensionController.swift
@@ -5,7 +5,6 @@
 //  Created by Mukesh Thawani on 05/06/18.
 //
 
-import Applozic
 import UIKit
 
 public class ALKAccountSuspensionController: UIViewController {

--- a/Sources/Controllers/ALKAccountSuspensionController.swift
+++ b/Sources/Controllers/ALKAccountSuspensionController.swift
@@ -18,11 +18,7 @@ public class ALKAccountSuspensionController: UIViewController {
     }
 
     @objc func closeButtonAction(_: UIButton) {
-        let topVC = ALPushAssist().topViewController
-        let vc = topVC?.presentingViewController
-        dismiss(animated: true) {
-            _ = vc?.navigationController?.popToRootViewController(animated: true)
-        }
+        closePressed?()
     }
 
     private func setupViews() {

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -29,6 +29,8 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
 
     var searchController: UISearchController!
     var searchBar: CustomSearchBar!
+    let registerUserClientService = ALRegisterUserClientService()
+
     lazy var resultVC = ALKSearchResultViewController(configuration: configuration)
 
     var dbService = ALMessageDBService()
@@ -337,11 +339,12 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
     open override func showAccountSuspensionView() {
         let accountVC = ALKAccountSuspensionController()
         present(accountVC, animated: false, completion: nil)
-        accountVC.closePressed = { [weak self] in
-            let popVC = self?.navigationController?.popViewController(animated: true)
-            if popVC == nil {
-                self?.navigationController?.dismiss(animated: true, completion: nil)
+        registerUserClientService.syncAccountStatus { response, error in
+            guard error == nil, let response = response, response.isRegisteredSuccessfully() else {
+                print("Failed to sync the account package status")
+                return
             }
+            print("Successfuly synced the account package status")
         }
     }
 

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -339,10 +339,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
     open override func showAccountSuspensionView() {
         let accountVC = ALKAccountSuspensionController()
         accountVC.closePressed = { [weak self] in
-            let popVC = self?.navigationController?.popViewController(animated: true)
-            if popVC == nil {
-                self?.navigationController?.dismiss(animated: true, completion: nil)
-            }
+            self?.dismiss(animated: true, completion: nil)
         }
         present(accountVC, animated: false, completion: nil)
         registerUserClientService.syncAccountStatus { response, error in

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -338,6 +338,12 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
 
     open override func showAccountSuspensionView() {
         let accountVC = ALKAccountSuspensionController()
+        accountVC.closePressed = { [weak self] in
+            let popVC = self?.navigationController?.popViewController(animated: true)
+            if popVC == nil {
+                self?.navigationController?.dismiss(animated: true, completion: nil)
+            }
+        }
         present(accountVC, animated: false, completion: nil)
         registerUserClientService.syncAccountStatus { response, error in
             guard error == nil, let response = response, response.isRegisteredSuccessfully() else {
@@ -345,12 +351,6 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
                 return
             }
             print("Successfuly synced the account package status")
-        }
-        accountVC.closePressed = { [weak self] in
-            let popVC = self?.navigationController?.popViewController(animated: true)
-            if popVC == nil {
-                self?.navigationController?.dismiss(animated: true, completion: nil)
-            }
         }
     }
 

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -346,6 +346,12 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
             }
             print("Successfuly synced the account package status")
         }
+        accountVC.closePressed = { [weak self] in
+            let popVC = self?.navigationController?.popViewController(animated: true)
+            if popVC == nil {
+                self?.navigationController?.dismiss(animated: true, completion: nil)
+            }
+        }
     }
 
     fileprivate func push(conversationVC: ALKConversationViewController, with viewModel: ALKConversationViewModel) {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -433,9 +433,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     open override func showAccountSuspensionView() {
         let accountVC = ALKAccountSuspensionController()
         accountVC.closePressed = { [weak self] in
-            accountVC.dismiss(animated: true) {
-                _ = self?.navigationController?.popToRootViewController(animated: true)
-            }
+            self?.dismiss(animated: true, completion: nil)
         }
         present(accountVC, animated: false, completion: nil)
         registerUserClientService.syncAccountStatus { response, error in

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -432,6 +432,11 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     open override func showAccountSuspensionView() {
         let accountVC = ALKAccountSuspensionController()
+        accountVC.closePressed = { [weak self] in
+            accountVC.dismiss(animated: true) {
+                _ = self?.navigationController?.popToRootViewController(animated: true)
+            }
+        }
         present(accountVC, animated: false, completion: nil)
         registerUserClientService.syncAccountStatus { response, error in
             guard error == nil, let response = response, response.isRegisteredSuccessfully() else {
@@ -439,11 +444,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 return
             }
             print("Successfuly synced the account  package status")
-        }
-        accountVC.closePressed = { [weak self] in
-            accountVC.dismiss(animated: true) {
-                _ = self?.navigationController?.popToRootViewController(animated: true)
-            }
         }
     }
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -54,6 +54,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     open lazy var navigationBar = ALKConversationNavBar(configuration: self.configuration, delegate: self)
 
     var contactService: ALContactService!
+    let registerUserClientService = ALRegisterUserClientService()
 
     var loadingIndicator = ALKLoadingIndicator(frame: .zero)
 
@@ -241,7 +242,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             print("new notification received: ", msgArray?.first?.message as Any, msgArray?.count ?? "")
             guard let list = notification.object as? [Any], !list.isEmpty, weakSelf.isViewLoaded else { return }
             weakSelf.viewModel.addMessagesToList(list)
-//            weakSelf.handlePushNotification = false
+            //            weakSelf.handlePushNotification = false
         })
 
         NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "notificationIndividualChat"), object: nil, queue: nil, using: {
@@ -432,8 +433,12 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     open override func showAccountSuspensionView() {
         let accountVC = ALKAccountSuspensionController()
         present(accountVC, animated: false, completion: nil)
-        accountVC.closePressed = { [weak self] in
-            _ = self?.navigationController?.popToRootViewController(animated: true)
+        registerUserClientService.syncAccountStatus { response, error in
+            guard error == nil, let response = response, response.isRegisteredSuccessfully() else {
+                print("Failed to sync the account package status")
+                return
+            }
+            print("Successfuly synced the account  package status ")
         }
     }
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -438,7 +438,12 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 print("Failed to sync the account package status")
                 return
             }
-            print("Successfuly synced the account  package status ")
+            print("Successfuly synced the account  package status")
+        }
+        accountVC.closePressed = { [weak self] in
+            accountVC.dismiss(animated: true) {
+                _ = self?.navigationController?.popToRootViewController(animated: true)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Added the method to fetch the package detail and Fixed the close button was not working in case of clicking on any contact to open the chat 

## Motivation
<!-- Why are you making this change? -->

## Testing
Tested with account closed and re activate   