### PR TITLE
[CM-168]Added config to disable in app notification banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ### Enhancements
 - Added support for syncing package details when a suspension screen is shown.
 - Added an option to change message status(read receipt) style. Now icon for message status can be changed from outside or it can be hidden.
+- Added a config to disable In-app notification banner, use ```config.isInAppNotificationBannerDisabled = true``` to disable In-app notification banner.
 
 ## [5.0.0] - 2020-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ### Enhancements
 - Added support for syncing package details when a suspension screen is shown.
 - Added an option to change message status(read receipt) style. Now icon for message status can be changed from outside or it can be hidden.
-- Added a config to disable In-app notification banner, use ```config.isInAppNotificationBannerDisabled = true``` to disable In-app notification banner.
-
+- Added a config to disable in-app notification banner.
+</br>You can use below config to disable in-app notification banner:
+```
+	config.isInAppNotificationBannerDisabled = true
+```
 ## [5.0.0] - 2020-02-14
 
 ### Enhancements

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -455,10 +455,12 @@ extension ALKConversationListViewController: ALMQTTConversationDelegate {
             viewModel.syncCall(viewController: viewController, message: message, isChatOpen: true)
 
         } else if !isMessageSentByLoggedInUser(alMessage: alMessage) {
-            let notificationView = ALNotificationView(alMessage: message, withAlertMessage: message.message)
-            notificationView?.showNativeNotificationWithcompletionHandler {
-                _ in
-                self.launchChat(contactId: message.contactId, groupId: message.groupId, conversationId: message.conversationId)
+            if !configuration.isInAppNotificationBannerDisabled {
+                let notificationView = ALNotificationView(alMessage: message, withAlertMessage: message.message)
+                notificationView?.showNativeNotificationWithcompletionHandler {
+                    _ in
+                    self.launchChat(contactId: message.contactId, groupId: message.groupId, conversationId: message.conversationId)
+                }
             }
         }
         if let visibleController = navigationController?.visibleViewController,

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -455,12 +455,14 @@ extension ALKConversationListViewController: ALMQTTConversationDelegate {
             viewModel.syncCall(viewController: viewController, message: message, isChatOpen: true)
 
         } else if !isMessageSentByLoggedInUser(alMessage: alMessage) {
-            if !configuration.isInAppNotificationBannerDisabled {
-                let notificationView = ALNotificationView(alMessage: message, withAlertMessage: message.message)
-                notificationView?.showNativeNotificationWithcompletionHandler {
-                    _ in
-                    self.launchChat(contactId: message.contactId, groupId: message.groupId, conversationId: message.conversationId)
-                }
+
+            guard !configuration.isInAppNotificationBannerDisabled else {
+                return
+            }
+            let notificationView = ALNotificationView(alMessage: message, withAlertMessage: message.message)
+            notificationView?.showNativeNotificationWithcompletionHandler {
+                _ in
+                self.launchChat(contactId: message.contactId, groupId: message.groupId, conversationId: message.conversationId)
             }
         }
         if let visibleController = navigationController?.visibleViewController,

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -975,6 +975,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             viewModel.syncOpenGroup(message: message)
             return
         }
+        guard !configuration.isInAppNotificationBannerDisabled else {
+            return
+        }
         guard message.conversationId == nil || message.conversationId != viewModel.conversationProxy?.id else {
             return
         }

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -148,7 +148,7 @@ public struct ALKConfiguration {
     // If true, Then message search will be enabled
     public var isMessageSearchEnabled: Bool = false
 
-    // If true, Then in-app notification banner will be disabled
+    // If true, then in-app notification banner will be disabled
     public var isInAppNotificationBannerDisabled: Bool = false
 
     /// If true, contact share option in chatbar will be hidden.

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -148,6 +148,9 @@ public struct ALKConfiguration {
     // If true, Then message search will be enabled
     public var isMessageSearchEnabled: Bool = false
 
+    // If true, Then in-app notification banner will be disabled
+    public var isInAppNotificationBannerDisabled: Bool = false
+
     /// If true, contact share option in chatbar will be hidden.
     @available(*, deprecated, message: "Use .chatBar.optionsToShow instead")
     public var hideContactInChatBar: Bool = false {

--- a/Sources/Utilities/ALKPushNotificationHandler.swift
+++ b/Sources/Utilities/ALKPushNotificationHandler.swift
@@ -32,6 +32,7 @@ public class ALKPushNotificationHandler: Localizable {
             case NSNumber(value: APP_STATE_ACTIVE.rawValue):
                 guard !NotificationHelper().isNotificationForActiveThread(notificationData) else { return }
                 // TODO: FIX HERE. USE conversationId also.
+                guard !configuration.isInAppNotificationBannerDisabled else { return }
                 ALUtilityClass.thirdDisplayNotificationTS(
                     message,
                     andForContactId: notificationData.userId,


### PR DESCRIPTION
## Summary
Added config for disabling the in-app notification 

## Motivation
<!-- Why are you making this change? -->

## Testing
Tested using the below config in the app delegate file and notification banner is disabled. Also, tested without config.

```swift
static let config: ALKConfiguration = {
     var config = ALKConfiguration()
     // Change config based on requirement like:
     config.isInAppNotificationBannerDisabled = true
     return config
 }() 
```