### PR TITLE
Update applozic pod to latest #trivial 

### DIFF
--- a/ApplozicSwift.podspec
+++ b/ApplozicSwift.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     complete.resources = 'Sources/**/*{lproj,storyboard,xib,xcassets,json}'
     complete.dependency 'Kingfisher', '~> 5.13.0'
     complete.dependency 'MGSwipeTableCell', '~> 1.6.11'
-    complete.dependency 'Applozic', '~> 7.1.0'
+    complete.dependency 'Applozic', '~> 7.2.0'
     complete.dependency 'ApplozicSwift/RichMessageKit'
   end
 end

--- a/Demo/ApplozicSwiftDemo/AppDelegate.swift
+++ b/Demo/ApplozicSwiftDemo/AppDelegate.swift
@@ -60,14 +60,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     func applicationDidEnterBackground(_: UIApplication) {
         print("APP_ENTER_IN_BACKGROUND")
-        NotificationCenter.default.post(name: Notification.Name(rawValue: "APP_ENTER_IN_BACKGROUND"), object: nil)
     }
 
     func applicationWillEnterForeground(_: UIApplication) {
-        ALPushNotificationService.applicationEntersForeground()
         print("APP_ENTER_IN_FOREGROUND")
-
-        NotificationCenter.default.post(name: Notification.Name(rawValue: "APP_ENTER_IN_FOREGROUND"), object: nil)
         UIApplication.shared.applicationIconBadgeNumber = 0
     }
 

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Applozic (7.1.0):
+  - Applozic (7.2.0):
     - SDWebImage (~> 5.1.0)
   - ApplozicSwift (5.1.0):
     - ApplozicSwift/Complete (= 5.1.0)
   - ApplozicSwift/Complete (5.1.0):
-    - Applozic (~> 7.1.0)
+    - Applozic (~> 7.2.0)
     - ApplozicSwift/RichMessageKit
     - Kingfisher (~> 5.13.0)
     - MGSwipeTableCell (~> 1.6.11)
@@ -14,9 +14,9 @@ PODS:
   - iOSSnapshotTestCase/Core (6.2.0)
   - iOSSnapshotTestCase/SwiftSupport (6.2.0):
     - iOSSnapshotTestCase/Core
-  - Kingfisher (5.13.1):
-    - Kingfisher/Core (= 5.13.1)
-  - Kingfisher/Core (5.13.1)
+  - Kingfisher (5.13.2):
+    - Kingfisher/Core (= 5.13.2)
+  - Kingfisher/Core (5.13.2)
   - MGSwipeTableCell (1.6.11)
   - Nimble (8.0.5)
   - Nimble-Snapshots (8.1.1):
@@ -28,7 +28,7 @@ PODS:
   - SDWebImage (5.1.1):
     - SDWebImage/Core (= 5.1.1)
   - SDWebImage/Core (5.1.1)
-  - SwiftFormat/CLI (0.44.2)
+  - SwiftFormat/CLI (0.44.4)
   - SwiftLint (0.39.1)
 
 DEPENDENCIES:
@@ -57,16 +57,16 @@ EXTERNAL SOURCES:
     :path: "../ApplozicSwift.podspec"
 
 SPEC CHECKSUMS:
-  Applozic: d4c79ed0d8a14fbf48d46fba4f6ee1729c64d264
-  ApplozicSwift: ab473cc5807abdd54872e77051db50f43d0fc7c6
+  Applozic: 5ced45cb804f9d9e9819a7839d8d9a70077839eb
+  ApplozicSwift: 2d68649f6611edbeea613ec1b629e31b30db09d8
   iOSSnapshotTestCase: 9ab44cb5aa62b84d31847f40680112e15ec579a6
-  Kingfisher: f33a848445e33c543620812158dc5d47f6bf90df
+  Kingfisher: d342c8354c10c3d85a27d6d4c42c41285924b898
   MGSwipeTableCell: b804e4e450dee439c42250be90bd50458bf67fce
   Nimble: 4ab1aeb9b45553c75b9687196b0fa0713170a332
   Nimble-Snapshots: 5058fb9b459e64371f54a0f8d9dde6f33db490a0
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
   SDWebImage: 96d7f03415ccb28d299d765f93557ff8a617abd8
-  SwiftFormat: 53968b5cc5d466727e796f789fa9be6c38da34cb
+  SwiftFormat: 8b3c6b69454305a61c221355095f62dacc0811bf
   SwiftLint: 55e96a4a4d537d4a3156859fc1c54bd24851a046
 
 PODFILE CHECKSUM: 37b1748ae38c7d600b4859d10af77ebc84042008

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -320,7 +320,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             weakSelf.newMessagesAdded()
         })
 
-        NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "APP_ENTER_IN_FOREGROUND"), object: nil, queue: nil) { [weak self] _ in
+        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
             guard let weakSelf = self, weakSelf.viewModel != nil else { return }
             weakSelf.viewModel.currentConversationProfile(completion: { profile in
                 guard let profile = profile else { return }
@@ -328,7 +328,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             })
         }
 
-        NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "APP_ENTER_IN_BACKGROUND"), object: nil, queue: nil) { [weak self] _ in
+        NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) { [weak self] _ in
             guard let weakSelf = self, weakSelf.viewModel != nil else { return }
             weakSelf.viewModel.sendKeyboardDoneTyping()
         }
@@ -345,8 +345,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name(rawValue: "UPDATE_MESSAGE_SEND_STATUS"), object: nil)
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name(rawValue: "USER_DETAILS_UPDATE_CALL"), object: nil)
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name(rawValue: "UPDATE_CHANNEL_NAME"), object: nil)
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name(rawValue: "APP_ENTER_IN_FOREGROUND"), object: nil)
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name(rawValue: "APP_ENTER_IN_BACKGROUND"), object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     open override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## Summary
* Update Applozic pod to fix the notification click message missing, 
* Remove the ref from app delegate for post notify and change the observer names to default apple name

## Motivation
<!-- Why are you making this change? -->

## Testing
Notification are triggering for did become active and background 