### PR TITLE
[CM-41] Add a method to scroll and allow overriding loading VM callbacks #trivial

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1482,11 +1482,11 @@ extension ALKConversationViewController: CNContactPickerDelegate {
 }
 
 extension ALKConversationViewController: ALKConversationViewModelDelegate {
-    public func loadingStarted() {
+    @objc open func loadingStarted() {
         activityIndicator.startAnimating()
     }
 
-    public func loadingFinished(error _: Error?) {
+    @objc open func loadingFinished(error _: Error?) {
         activityIndicator.stopAnimating()
         let oldSectionCount = tableView.numberOfSections
         tableView.reloadData()
@@ -1592,6 +1592,16 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         let profile = viewModel.conversationProfileFrom(contact: contact, channel: channel)
         navigationBar.updateView(profile: profile)
     }
+
+    // Call this if the last message is not fully visible.
+    // This happens when chatbar's header height increases later on.
+    public func showLastMessage() {
+        if tableView.isCellVisible(section: viewModel.messageModels.count - 2, row: 0) {
+            let indexPath: IndexPath = IndexPath(row: 0, section: viewModel.messageModels.count - 1)
+            moveTableViewToBottom(indexPath: indexPath)
+        }
+    }
+
 
     func rightNavbarButton() -> UIBarButtonItem? {
         guard !configuration.hideRightNavBarButtonForConversationView else {


### PR DESCRIPTION
## Summary
Added a method to scroll to bottom if last messages are not visible. If you pass a view in chatbar's header, and if the height is updated after message list has been loaded, then some last messages were not visible. In that case this method will be called to scroll down.

And now it's possible to override the ViewModel callbacks like `loadingStarted` and `loadingFinished`. This will be helpful to start other processes once messages are loaded.

## Motivation
<!-- Why are you making this change? -->
It was not possible to scroll down using current methods.

## Testing
Tested it in KM sample app to show last message on group update notifications.