### PR TITLE
[CM-199] Lower context view's top constraint priority #trivial

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -529,8 +529,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         backgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         backgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
         backgroundView.bottomAnchor.constraint(equalTo: chatBar.topAnchor).isActive = true
-
-        contextTitleView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        let contextViewTopCons = contextTitleView.topAnchor.constraint(equalTo: view.topAnchor)
+        contextViewTopCons.priority = .init(rawValue: 750)
+        contextViewTopCons.isActive = true
         contextTitleView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         contextTitleView.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
         contextTitleView.heightAnchor.constraintEqualToAnchor(constant: 0, identifier: ConstraintIdentifier.contextTitleView).isActive = true


### PR DESCRIPTION
## Summary
Set the priority of context view's top constraint priority to 750. This is required to add a header view on top.  Now we can apply a high priority to another top constrain of context view.

## Testing
No changes in the current view.