### PR TITLE
[CM-225] Fixed the group profile was removing when we update group name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ You can read more on Property List Keys
 ### Fixes
 - [CM-146] Fixed back button issue in searched conversation view.
 - [CM-241] Fixed a crash that could happen when some message updates are delayed.
+- [CM-225] Fixed an issue where group profile was getting removed on group name update.
 
 ## [5.3.0] - 2020-04-21
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1699,7 +1699,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
 }
 
 extension ALKConversationViewController: ALKCreateGroupChatAddFriendProtocol {
-    func createGroupGetFriendInGroupList(friendsSelected _: [ALKFriendViewModel], groupName: String, groupImgUrl: String, friendsAdded: [ALKFriendViewModel]) {
+    func createGroupGetFriendInGroupList(friendsSelected _: [ALKFriendViewModel], groupName: String, groupImgUrl: String?, friendsAdded: [ALKFriendViewModel]) {
         if viewModel.isGroup {
             viewModel.updateGroup(groupName: groupName, groupImage: groupImgUrl, friendsAdded: friendsAdded)
             _ = navigationController?.popToViewController(self, animated: true)

--- a/Sources/Controllers/ALKCreateGroupViewController.swift
+++ b/Sources/Controllers/ALKCreateGroupViewController.swift
@@ -14,7 +14,7 @@ protocol ALKCreateGroupChatAddFriendProtocol: AnyObject {
     func createGroupGetFriendInGroupList(
         friendsSelected: [ALKFriendViewModel],
         groupName: String,
-        groupImgUrl: String,
+        groupImgUrl: String?,
         friendsAdded: [ALKFriendViewModel]
     )
 }
@@ -163,7 +163,7 @@ final class ALKCreateGroupViewController: ALKBaseViewController, Localizable {
                 })
             } else {
                 // Pass groupImgUrl empty in case of group name update
-                groupDelegate?.createGroupGetFriendInGroupList(friendsSelected: groupList, groupName: groupName, groupImgUrl: "", friendsAdded: addedList)
+                groupDelegate?.createGroupGetFriendInGroupList(friendsSelected: groupList, groupName: groupName, groupImgUrl: nil, friendsAdded: addedList)
             }
         }
     }

--- a/Sources/Controllers/ALKNewChatViewController.swift
+++ b/Sources/Controllers/ALKNewChatViewController.swift
@@ -205,7 +205,7 @@ extension ALKNewChatViewController: UISearchBarDelegate {
 // MARK: - CreateGroupChatAddFriendProtocol
 
 extension ALKNewChatViewController: ALKCreateGroupChatAddFriendProtocol {
-    func createGroupGetFriendInGroupList(friendsSelected: [ALKFriendViewModel], groupName: String, groupImgUrl: String, friendsAdded _: [ALKFriendViewModel]) {
+    func createGroupGetFriendInGroupList(friendsSelected: [ALKFriendViewModel], groupName: String, groupImgUrl: String?, friendsAdded _: [ALKFriendViewModel]) {
         guard ALDataNetworkConnection.checkDataNetworkAvailable() else { return }
 
         // Server call

--- a/Sources/Controllers/ALKSearchResultViewController.swift
+++ b/Sources/Controllers/ALKSearchResultViewController.swift
@@ -84,7 +84,6 @@ public class ALKSearchResultViewController: ALKBaseViewController {
         view.addSubview(activityIndicator)
         view.bringSubviewToFront(activityIndicator)
     }
-
 }
 
 extension ALKSearchResultViewController: ALKConversationListTableViewDelegate {

--- a/Sources/Utilities/ALKHTTPManager.swift
+++ b/Sources/Utilities/ALKHTTPManager.swift
@@ -57,7 +57,7 @@ class ALKHTTPManager: NSObject {
     }
 
     func upload(image: UIImage, uploadURL: URL, completion: @escaping (_ imageLink: Data?) -> Void) {
-        guard var request = ALRequestHandler.createPOSTRequest(withUrlString: uploadURL.path, paramString: nil) as URLRequest? else { return }
+        guard var request = ALRequestHandler.createPOSTRequest(withUrlString: uploadURL.absoluteString, paramString: nil) as URLRequest? else { return }
 
         let boundary = "------ApplogicBoundary4QuqLuM1cE5lMwCy"
         let contentType = String(format: "multipart/form-data; boundary=%@", boundary)

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -586,8 +586,8 @@ open class ALKConversationViewModel: NSObject, Localizable {
         }
     }
 
-    open func updateGroup(groupName: String, groupImage: String, friendsAdded: [ALKFriendViewModel]) {
-        if !groupName.isEmpty || !groupImage.isEmpty {
+    open func updateGroup(groupName: String, groupImage: String?, friendsAdded: [ALKFriendViewModel]) {
+        if !groupName.isEmpty || groupImage != nil {
             updateGroupInfo(groupName: groupName, groupImage: groupImage, completion: { success in
                 self.updateInfo()
                 guard success, !friendsAdded.isEmpty else { return }
@@ -1345,7 +1345,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
 
     private func updateGroupInfo(
         groupName: String,
-        groupImage: String,
+        groupImage: String?,
         completion: @escaping (Bool) -> Void
     ) {
         guard let groupId = groupKey() else { return }


### PR DESCRIPTION
## Summary
The group icon was removed due to the passing of an empty string. 

## Motivation
<!-- Why are you making this change? -->

## Testing
* Tested with changing the group icon 
* Tested with changing the group name 
* Tested by change name and group icon  
 All the cases work fine.