### PR TITLE
Add config for disable the button tint color #trivial 

### DIFF
--- a/Sources/Models/ALKChatBarConfiguration.swift
+++ b/Sources/Models/ALKChatBarConfiguration.swift
@@ -26,6 +26,9 @@ public struct ALKChatBarConfiguration {
         case some([AttachmentType])
     }
 
+    /// If true then button tint color will be disabled for attachment buttons, send button.
+    public var disableButtonTintColor = false
+
     /// Use this to set the `AttachmentOptions` you want to show.
     /// By default it is set to `all`.
     public var optionsToShow: AttachmentOptions = .all

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -41,10 +41,7 @@ public struct ALKConfiguration {
 
     /// Send message icon in chat bar.
     public var sendMessageIcon = UIImage(named: "send", in: Bundle.applozic, compatibleWith: nil)
-
-    /// If true then  button tint color will be disabled for attachment buttons, send button.
-    public var disableButtonTintColor = false
-
+    
     /// Image for navigation bar right side icon in conversation view.
     @available(*, deprecated, message: "Use navigationItemsForConversationView instead")
     public var rightNavBarImageForConversationView: UIImage?

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -42,8 +42,8 @@ public struct ALKConfiguration {
     /// Send message icon in chat bar.
     public var sendMessageIcon = UIImage(named: "send", in: Bundle.applozic, compatibleWith: nil)
 
-    /// If true then send button tint color will be disabled.
-    public var disableSendButtonTintColor = false
+    /// If true then  button tint color will be disabled for attachment buttons, send button.
+    public var disableButtonTintColor = false
 
     /// Image for navigation bar right side icon in conversation view.
     @available(*, deprecated, message: "Use navigationItemsForConversationView instead")

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -42,6 +42,9 @@ public struct ALKConfiguration {
     /// Send message icon in chat bar.
     public var sendMessageIcon = UIImage(named: "send", in: Bundle.applozic, compatibleWith: nil)
 
+    /// If true then send button tint color will be disabled.
+    public var disableSendButtonTintColor = false
+
     /// Image for navigation bar right side icon in conversation view.
     @available(*, deprecated, message: "Use navigationItemsForConversationView instead")
     public var rightNavBarImageForConversationView: UIImage?

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -299,7 +299,10 @@ open class ALKChatBar: UIView, Localizable {
         micButton.setButtonTintColor(color: sendButtonTintColor)
         var image = configuration.sendMessageIcon
         image = image?.imageFlippedForRightToLeftLayoutDirection().withRenderingMode(.alwaysTemplate)
-        sendButton.imageView?.tintColor = sendButtonTintColor
+
+        if !configuration.disableSendButtonTintColor {
+            sendButton.imageView?.tintColor = sendButtonTintColor
+        }
         sendButton.setImage(image, for: .normal)
 
         if configuration.hideLineImageFromChatBar {

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -299,7 +299,7 @@ open class ALKChatBar: UIView, Localizable {
         micButton.setButtonTintColor(color: buttonTintColor)
         var image = configuration.sendMessageIcon
         image = image?.imageFlippedForRightToLeftLayoutDirection()
-        if !configuration.disableButtonTintColor {
+        if !chatBarConfiguration.disableButtonTintColor {
             image = image?.withRenderingMode(.alwaysTemplate)
             sendButton.imageView?.tintColor = buttonTintColor
         }
@@ -643,7 +643,7 @@ open class ALKChatBar: UIView, Localizable {
             var image = image?.imageFlippedForRightToLeftLayoutDirection()
             image = image?.scale(with: size)
             if tintColor != nil,
-                !configuration.disableButtonTintColor {
+                !chatBarConfiguration.disableButtonTintColor {
                 image = image?.withRenderingMode(.alwaysTemplate)
                 button.imageView?.tintColor = tintColor
             }

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -293,15 +293,15 @@ open class ALKChatBar: UIView, Localizable {
         locationButton.addTarget(self, action: #selector(tapped(button:)), for: .touchUpInside)
         contactButton.addTarget(self, action: #selector(tapped(button:)), for: .touchUpInside)
         let appSettingsUserDefaults = ALKAppSettingsUserDefaults()
-        let sendButtonTintColor = appSettingsUserDefaults.getAttachmentIconsTintColor()
-        setupAttachment(buttonIcons: chatBarConfiguration.attachmentIcons, tintColor: sendButtonTintColor)
+        let buttonTintColor = appSettingsUserDefaults.getAttachmentIconsTintColor()
+        setupAttachment(buttonIcons: chatBarConfiguration.attachmentIcons, tintColor: buttonTintColor)
         setupConstraints()
-        micButton.setButtonTintColor(color: sendButtonTintColor)
+        micButton.setButtonTintColor(color: buttonTintColor)
         var image = configuration.sendMessageIcon
-        image = image?.imageFlippedForRightToLeftLayoutDirection().withRenderingMode(.alwaysTemplate)
-
-        if !configuration.disableSendButtonTintColor {
-            sendButton.imageView?.tintColor = sendButtonTintColor
+        image = image?.imageFlippedForRightToLeftLayoutDirection()
+        if !configuration.disableButtonTintColor {
+            image = image?.withRenderingMode(.alwaysTemplate)
+            sendButton.imageView?.tintColor = buttonTintColor
         }
         sendButton.setImage(image, for: .normal)
 
@@ -641,11 +641,13 @@ open class ALKChatBar: UIView, Localizable {
             withSize size: CGSize = CGSize(width: 25, height: 25)
         ) {
             var image = image?.imageFlippedForRightToLeftLayoutDirection()
-            image = image?.scale(with: size)?.withRenderingMode(.alwaysTemplate)
-            button.setImage(image, for: .normal)
-            if tintColor != nil {
+            image = image?.scale(with: size)
+            if tintColor != nil,
+                !configuration.disableButtonTintColor {
+                image = image?.withRenderingMode(.alwaysTemplate)
                 button.imageView?.tintColor = tintColor
             }
+            button.setImage(image, for: .normal)
         }
 
         for option in AttachmentType.allCases {


### PR DESCRIPTION
## Summary
Add config for disable the button tint color for attachments and send message 
## Motivation
<!-- Why are you making this change? -->

## Testing

Tried with `config.disableButtonTintColor = true` it will disable the tint color and uses the image as we set in config for buttons 

Example: Add the config in the app delegate config object and should take same color which the which is in the image 

```
config.sendMessageIcon = UIImage(named: "send", in: Bundle(for: ALKConversationListViewController.self), compatibleWith: nil)
     config.disableButtonTintColor = true
```