### PR TITLE
[CM-357] Handle form item colors in dark mode

### DIFF
--- a/Sources/Utilities/UITextField+Extension.swift
+++ b/Sources/Utilities/UITextField+Extension.swift
@@ -9,6 +9,17 @@
 import Foundation
 
 extension UITextField {
+    var placeholderColor: UIColor {
+        get {
+            return attributedPlaceholder?.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? UIColor ?? .clear
+        }
+        set {
+            guard let attributedPlaceholder = attributedPlaceholder else { return }
+            let attributes: [NSAttributedString.Key: UIColor] = [.foregroundColor: newValue]
+            self.attributedPlaceholder = NSAttributedString(string: attributedPlaceholder.string, attributes: attributes)
+        }
+    }
+
     func trimmedWhitespaceText() -> String {
         if let text = self.text {
             return text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -59,6 +59,7 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
         itemListView.separatorStyle = .singleLine
         itemListView.allowsSelection = false
         itemListView.isScrollEnabled = false
+        itemListView.alwaysBounceVertical = false
         itemListView.delegate = self
         itemListView.dataSource = self
         itemListView.tableFooterView = UIView(frame: .zero)

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -53,11 +53,12 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
 
     private func setUpTableView() {
         itemListView.backgroundColor = .white
-        itemListView.estimatedRowHeight = 50
-        itemListView.estimatedSectionHeaderHeight = 50
+        itemListView.estimatedRowHeight = 40
+        itemListView.estimatedSectionHeaderHeight = 40
         itemListView.rowHeight = UITableView.automaticDimension
         itemListView.separatorStyle = .singleLine
         itemListView.allowsSelection = false
+        itemListView.isScrollEnabled = false
         itemListView.delegate = self
         itemListView.dataSource = self
         itemListView.tableFooterView = UIView(frame: .zero)

--- a/Sources/Views/ALKFormMultiSelectItemCell.swift
+++ b/Sources/Views/ALKFormMultiSelectItemCell.swift
@@ -31,6 +31,8 @@ class ALKFormMultiSelectItemCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(onSelection))
         contentView.addGestureRecognizer(tapRecognizer)
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
         addConstraints()
     }
 

--- a/Sources/Views/ALKFormPasswordItemCell.swift
+++ b/Sources/Views/ALKFormPasswordItemCell.swift
@@ -14,7 +14,9 @@ class ALKFormPasswordItemCell: UITableViewCell {
                 return
             }
             nameLabel.text = item.label
-            valueTextField.placeholder = item.placeholder
+            valueTextField.attributedPlaceholder =
+                NSAttributedString(string: item.placeholder ?? "")
+            valueTextField.placeholderColor = .lightGray
         }
     }
 
@@ -35,6 +37,9 @@ class ALKFormPasswordItemCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        valueTextField.textColor = .black
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
         addConstraints()
     }
 

--- a/Sources/Views/ALKFormSingleSelectItemCell.swift
+++ b/Sources/Views/ALKFormSingleSelectItemCell.swift
@@ -31,6 +31,8 @@ class ALKFormSingleSelectItemCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(onSelection))
         contentView.addGestureRecognizer(tapRecognizer)
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
         addConstraints()
     }
 

--- a/Sources/Views/ALKFormTextItemCell.swift
+++ b/Sources/Views/ALKFormTextItemCell.swift
@@ -14,7 +14,9 @@ class ALKFormTextItemCell: UITableViewCell {
                 return
             }
             nameLabel.text = item.label
-            valueTextField.placeholder = item.placeholder
+            valueTextField.attributedPlaceholder =
+                NSAttributedString(string: item.placeholder ?? "")
+            valueTextField.placeholderColor = .lightGray
         }
     }
 
@@ -34,6 +36,9 @@ class ALKFormTextItemCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        valueTextField.textColor = .black
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
         addConstraints()
     }
 

--- a/Sources/Views/ALKFriendFormCell.swift
+++ b/Sources/Views/ALKFriendFormCell.swift
@@ -80,6 +80,7 @@ class ALKFriendFormCell: ALKFormCell {
     }
 
     override func update(viewModel: ALKMessageViewModel) {
+        super.update(viewModel: viewModel)
         let isMessageEmpty = viewModel.isMessageEmpty
         let maxWidth = UIScreen.main.bounds.width
         let messageWidth = maxWidth - (ChatCellPadding.ReceivedMessage.Message.left +
@@ -103,7 +104,6 @@ class ALKFriendFormCell: ALKFormCell {
         timeLabelHeight.constant = timeLabelSize.height.rounded(.up)
         timeLabelWidth.constant = timeLabelSize.width.rounded(.up)
         layoutIfNeeded()
-        super.update(viewModel: viewModel)
     }
 
     private func setupConstraints() {


### PR DESCRIPTION
## Summary
- Colors of form item views were changing in the dark mode, so to avoid that I've set the default colors like we do in other views.
- This also contains a fix for submit button visibility issue in the form cell. It was not visible when a new message comes.

## Testing
Tested in dark mode and by sending form messages when the conversation is open.