### PR TITLE
Add Form data cache and end editing once submit is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ## [Unreleased]
 
+### Fixes
+- Fixed the issue where form data submit was using data from previous cell.
+
 ## [5.8.0] - 2020-07-15
 
 ### Enhancements

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -493,6 +493,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 cell.activeTextFieldChanged = { textField in
                     self.activeTextField = textField
                 }
+                cell.identifier = message.identifier
                 cell.update(viewModel: message)
                 return cell
             } else {
@@ -500,6 +501,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 cell.activeTextFieldChanged = { textField in
                     self.activeTextField = textField
                 }
+                cell.identifier = message.identifier
                 cell.update(viewModel: message)
                 cell.tapped = { [weak self] index, name, submitData in
                     guard let weakSelf = self else { return }

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -493,7 +493,6 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 cell.activeTextFieldChanged = { textField in
                     self.activeTextField = textField
                 }
-                cell.identifier = message.identifier
                 cell.update(viewModel: message)
                 return cell
             } else {
@@ -501,7 +500,6 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 cell.activeTextFieldChanged = { textField in
                     self.activeTextField = textField
                 }
-                cell.identifier = message.identifier
                 cell.update(viewModel: message)
                 cell.tapped = { [weak self] index, name, submitData in
                     guard let weakSelf = self else { return }

--- a/Sources/Utilities/ALKFormDataCache.swift
+++ b/Sources/Utilities/ALKFormDataCache.swift
@@ -1,0 +1,35 @@
+//
+//  ALKFormDataCache.swift
+//  ApplozicSwift
+//
+//  Created by Sunil on 20/07/20.
+//
+
+import Foundation
+/// `ALKFormDataCache`class will be used for form data cache
+class ALKFormDataCache {
+    static let shared = ALKFormDataCache()
+    private let cache = NSCache<NSString, FormDataSubmit>()
+
+    private init() {
+        cache.name = "FormDataCache"
+    }
+
+    func set(_ formDataSubmit: FormDataSubmit, for key: String) {
+        cache.setObject(formDataSubmit, forKey: key as NSString)
+    }
+
+    func getFormData(for key: String) -> FormDataSubmit? {
+        guard let formDataSubmit = cache.object(forKey: key as NSString) else {
+            return nil
+        }
+        return formDataSubmit
+    }
+
+    func getFormDataWithDefaultObject(for key: String) -> FormDataSubmit {
+        guard let formDataSubmit = cache.object(forKey: key as NSString) else {
+            return FormDataSubmit()
+        }
+        return formDataSubmit
+    }
+}

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -18,20 +18,19 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
         }
     }
     var activeTextFieldChanged: ((UITextField?) -> Void)?
-    var shared = ALKFormDataCache.shared
+    var formDataCacheStore = ALKFormDataCache.shared
 
     var formData: FormDataSubmit? {
         get {
-
             guard let key = identifier else {
                 return nil
             }
-            return shared.getFormDataWithDefaultObject(for: key)
+            return formDataCacheStore.getFormDataWithDefaultObject(for: key)
         }
         set(newFormData) {
             guard let key = identifier,
                 let formData = newFormData else { return }
-            shared.set(formData, for: key)
+            formDataCacheStore.set(formData, for: key)
         }
     }
 
@@ -141,8 +140,7 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
             }
             cell.item = singleselectItem.options[indexPath.row]
 
-            if let key = self.identifier,
-                let formDataSubmit = shared.getFormData(for:key),
+            if let formDataSubmit = formData,
                 let singleSelectFields = formDataSubmit.singleSelectFields[indexPath.section],
                 singleSelectFields == indexPath.row {
                 cell.accessoryType = .checkmark
@@ -178,8 +176,7 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
                 }
             }
 
-            if let key = self.identifier,
-                let formDataSubmit = shared.getFormData(for:key),
+            if let formDataSubmit = formData,
                 let multiSelectFields = formDataSubmit.multiSelectFields[indexPath.section], multiSelectFields.contains(indexPath.row) {
                 cell.accessoryType = .checkmark
             } else {

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -165,6 +165,7 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
 
 extension ALKFormCell: Tappable {
     func didTap(index: Int?, title: String) {
+        self.endEditing(true)
         print("tapped submit button in the form")
         guard let tapped = tapped, let index = index else { return }
         tapped(index, title, formDataSubmit)

--- a/Sources/Views/ALKFriendFormCell.swift
+++ b/Sources/Views/ALKFriendFormCell.swift
@@ -80,6 +80,7 @@ class ALKFriendFormCell: ALKFormCell {
     }
 
     override func update(viewModel: ALKMessageViewModel) {
+        self.identifier = viewModel.identifier
         super.update(viewModel: viewModel)
         let isMessageEmpty = viewModel.isMessageEmpty
         let maxWidth = UIScreen.main.bounds.width

--- a/Sources/Views/ALKMyFormCell.swift
+++ b/Sources/Views/ALKMyFormCell.swift
@@ -50,6 +50,7 @@ class ALKMyFormCell: ALKFormCell {
     }
 
     override func update(viewModel: ALKMessageViewModel) {
+        self.identifier = viewModel.identifier
         let isMessageEmpty = viewModel.isMessageEmpty
         let maxWidth = UIScreen.main.bounds.width
         let messageWidth = maxWidth - (ChatCellPadding.SentMessage.Message.left +


### PR DESCRIPTION
## Summary
* Form data text field was not adding the text of the last text field  as the focus of the text field was in the last editing text field
Force the edit text field to end once the submit button clicked.

*Form data cache for submitting data 


## Motivation
<!-- Why are you making this change? -->

## Testing
Tried in the checking JSON of the submit click and tried with multiple forms and checking if the form data is going for current submit button click  