### PR TITLE
[CM-417] Fixed a crash that occurred due to nav bar items limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ### Enhancements
 - [CM-384] Added document sharing support.
+### Fixes
+- [CM-417] Fixed a crash that occurred in iOS 13.5 after going back from the group detail or document viewer to a conversation thread.
 
 ## [5.8.2] - 2020-07-24
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -597,6 +597,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             navigationBar.setupAppearance(navBar)
         }
         var items: [UIBarButtonItem] = navigationItem.leftBarButtonItems ?? []
+        guard !items.contains(where: { $0.customView == navigationBar }) else { return }
         items.append(UIBarButtonItem(customView: navigationBar))
         navigationItem.leftBarButtonItems = items
     }


### PR DESCRIPTION
## Summary
- Fixed a crash that occurred in iOS 13.5 after going back from the group detail or document viewer to a conversation thread.
- We were adding same nav bar items multiple times, and it was crossing the limit.
- Added a check to only add custom nav bar when it's not present.

## Testing
Tested by launching group detail and document viewer multiple times from the conversation screen.