### PR TITLE
Support dynamic text of any size in form selection items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ## [Unreleased]
 
+### Enhancements
+- Removed the line limit of form selection items to allow dynamic text of any size.
+
 ## [5.9.1] - 2020-08-18
 
 ### Enhancements

--- a/Sources/Views/ALKFormMultiSelectItemCell.swift
+++ b/Sources/Views/ALKFormMultiSelectItemCell.swift
@@ -22,7 +22,7 @@ class ALKFormMultiSelectItemCell: UITableViewCell {
         let label = UILabel(frame: .zero)
         label.font = Font.medium(size: 17).font()
         label.textColor = .black
-        label.numberOfLines = 4
+        label.numberOfLines = 0
         label.textAlignment = .left
         return label
     }()

--- a/Sources/Views/ALKFormSingleSelectItemCell.swift
+++ b/Sources/Views/ALKFormSingleSelectItemCell.swift
@@ -22,7 +22,7 @@ class ALKFormSingleSelectItemCell: UITableViewCell {
         let label = UILabel(frame: .zero)
         label.font = Font.medium(size: 17).font()
         label.textColor = .black
-        label.numberOfLines = 4
+        label.numberOfLines = 0
         label.textAlignment = .left
         return label
     }()

--- a/Sources/Views/ALKFormTextItemCell.swift
+++ b/Sources/Views/ALKFormTextItemCell.swift
@@ -76,7 +76,7 @@ class ALKFormItemHeaderView: UITableViewHeaderFooterView {
         let label = UILabel(frame: .zero)
         label.font = Font.normal(size: 17).font()
         label.textColor = .text(.gray7E)
-        label.numberOfLines = 3
+        label.numberOfLines = 0
         label.textAlignment = .left
         return label
     }()


### PR DESCRIPTION
## Summary
- Removed the line limit of form selection items to allow dynamic text of any size.

## Motivation
To allow form item options of different character count.

## Testing
Tested with a form template message that had some options of 1 line and some of 3-4 lines, all are rendering properly now.