### PR TITLE
Set the default color in contentView of empty view#trivial 

### DIFF
--- a/Sources/Controllers/ALKConversationListTableViewController.swift
+++ b/Sources/Controllers/ALKConversationListTableViewController.swift
@@ -185,6 +185,7 @@ public class ALKConversationListTableViewController: UITableViewController, Loca
         let noConversationLabelText = localizedString(forKey: "NoConversationsLabelText", withDefaultValue: SystemMessage.ChatList.NoConversationsLabelText, fileName: localizedStringFileName)
         emptyCellView.conversationLabel.text = noConversationLabelText
         emptyCellView.startNewConversationButtonIcon.isHidden = configuration.hideEmptyStateStartNewButtonInConversationList
+        emptyCellView.contentView.backgroundColor = .white
 
         if !configuration.hideEmptyStateStartNewButtonInConversationList {
             if let tap = emptyCellView.gestureRecognizers?.first {


### PR DESCRIPTION
## Summary
in iPhone iOS 14 the color background of empty view is cleared
The background color only in iOS 14 it was showing as gray.

Before 
![IMG_0045](https://user-images.githubusercontent.com/11742961/93859241-03340680-fcdb-11ea-904a-33e228b41db4.PNG)

Now: 
![IMG_0046](https://user-images.githubusercontent.com/11742961/93859261-0929e780-fcdb-11ea-8768-7b993372cb03.PNG)


## Motivation
<!-- Why are you making this change? -->

## Testing
Tested by changing the color to match the table view bg color.