### PR TITLE
[CM-451] Add the support for passing prefilled message while launching the chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ### Enhancements
 - [CM-402] Date picker support in form template.
 - [CM-402] Text validation support in form template.
+- [CM-451] Add support for setting a prefilled message to send before launching a chat.
 
 ## [5.10.2] - 2020-10-06
 

--- a/Demo/ApplozicSwiftDemo/ALChatManager.swift
+++ b/Demo/ApplozicSwiftDemo/ALChatManager.swift
@@ -145,24 +145,24 @@ class ALChatManager: NSObject {
         vc.navigationController?.pushViewController(viewController, animated: false)
     }
 
-    func launchChatWith(contactId: String, prefilledMessage: String? = nil, from viewController: UIViewController, configuration: ALKConfiguration) {
+    func launchChatWith(contactId: String, from viewController: UIViewController, configuration: ALKConfiguration, prefilledMessage: String? = nil) {
         let alContactDbService = ALContactDBService()
         var title = ""
         if let alContact = alContactDbService.loadContact(byKey: "userId", value: contactId), let name = alContact.getDisplayName() {
             title = name
         }
         title = title.isEmpty ? "No name" : title
-        let convViewModel = ALKConversationViewModel(contactId: contactId, channelKey: nil, localizedStringFileName: configuration.localizedStringFileName, prefilledMessage : prefilledMessage)
+        let convViewModel = ALKConversationViewModel(contactId: contactId, channelKey: nil, localizedStringFileName: configuration.localizedStringFileName, prefilledMessage: prefilledMessage)
         let conversationViewController = ALKConversationViewController(configuration: configuration)
         conversationViewController.viewModel = convViewModel
         launch(viewController: conversationViewController, from: viewController)
     }
 
-    func launchGroupWith(clientGroupId: String, prefilledMessage: String? = nil, from viewController: UIViewController, configuration: ALKConfiguration) {
+    func launchGroupWith(clientGroupId: String, from viewController: UIViewController, configuration: ALKConfiguration, prefilledMessage: String? = nil) {
         let alChannelService = ALChannelService()
         alChannelService.getChannelInformation(nil, orClientChannelKey: clientGroupId) { channel in
             guard let channel = channel, let key = channel.key else { return }
-            let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: key, localizedStringFileName: configuration.localizedStringFileName, prefilledMessage :prefilledMessage)
+            let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: key, localizedStringFileName: configuration.localizedStringFileName, prefilledMessage: prefilledMessage)
             let conversationViewController = ALKConversationViewController(configuration: configuration)
             conversationViewController.viewModel = convViewModel
             self.launch(viewController: conversationViewController, from: viewController)

--- a/Demo/ApplozicSwiftDemo/ALChatManager.swift
+++ b/Demo/ApplozicSwiftDemo/ALChatManager.swift
@@ -145,24 +145,24 @@ class ALChatManager: NSObject {
         vc.navigationController?.pushViewController(viewController, animated: false)
     }
 
-    func launchChatWith(contactId: String, from viewController: UIViewController, configuration: ALKConfiguration) {
+    func launchChatWith(contactId: String, prefilledMessage: String? = nil, from viewController: UIViewController, configuration: ALKConfiguration) {
         let alContactDbService = ALContactDBService()
         var title = ""
         if let alContact = alContactDbService.loadContact(byKey: "userId", value: contactId), let name = alContact.getDisplayName() {
             title = name
         }
         title = title.isEmpty ? "No name" : title
-        let convViewModel = ALKConversationViewModel(contactId: contactId, channelKey: nil, localizedStringFileName: configuration.localizedStringFileName)
+        let convViewModel = ALKConversationViewModel(contactId: contactId, channelKey: nil, localizedStringFileName: configuration.localizedStringFileName, prefilledMessage : prefilledMessage)
         let conversationViewController = ALKConversationViewController(configuration: configuration)
         conversationViewController.viewModel = convViewModel
         launch(viewController: conversationViewController, from: viewController)
     }
 
-    func launchGroupWith(clientGroupId: String, from viewController: UIViewController, configuration: ALKConfiguration) {
+    func launchGroupWith(clientGroupId: String, prefilledMessage: String? = nil, from viewController: UIViewController, configuration: ALKConfiguration) {
         let alChannelService = ALChannelService()
         alChannelService.getChannelInformation(nil, orClientChannelKey: clientGroupId) { channel in
             guard let channel = channel, let key = channel.key else { return }
-            let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: key, localizedStringFileName: configuration.localizedStringFileName)
+            let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: key, localizedStringFileName: configuration.localizedStringFileName, prefilledMessage :prefilledMessage)
             let conversationViewController = ALKConversationViewController(configuration: configuration)
             conversationViewController.viewModel = convViewModel
             self.launch(viewController: conversationViewController, from: viewController)

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -677,6 +677,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
 
     public func configureChatBar() {
+        chatBar.setDefaultText(viewModel.prefilledMessage ?? "")
         if viewModel.isOpenGroup {
             chatBar.updateMediaViewVisibility(hide: true)
             chatBar.hideMicButton()
@@ -999,7 +1000,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             let notificationView = ALNotificationView(alMessage: message, withAlertMessage: message.message)
             notificationView?.showNativeNotificationWithcompletionHandler {
                 _ in
+
                 self.viewModel.contactId = nil
+                self.viewModel.prefilledMessage = nil
                 self.viewModel.channelKey = groupId
                 self.viewModel.isFirstTime = true
                 self.refreshViewController()
@@ -1010,6 +1013,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 _ in
                 self.viewModel.contactId = contactId
                 self.viewModel.channelKey = nil
+                self.viewModel.prefilledMessage = nil
                 self.viewModel.isFirstTime = true
                 self.refreshViewController()
             }

--- a/Sources/Utilities/NotificationHelper.swift
+++ b/Sources/Utilities/NotificationHelper.swift
@@ -122,6 +122,11 @@ public class NotificationHelper {
     ///   - notification: notification that is tapped.
     public func refreshConversation(_ viewController: ALKConversationViewController, with notification: NotificationData) {
         viewController.unsubscribingChannel()
+        if !self.isChatThreadIsOpen(notification,
+                                    userId: viewController.viewModel.contactId,
+                                    groupId: viewController.viewModel.channelKey) {
+            viewController.viewModel.prefilledMessage = nil
+        }
         viewController.viewModel.contactId = notification.userId
         viewController.viewModel.channelKey = notification.groupId
         var convProxy: ALConversationProxy?
@@ -145,13 +150,14 @@ public class NotificationHelper {
              "ALKWebViewController",
              "SelectProfilePicViewController",
              "CNContactPickerViewController",
-             "CAMImagePickerCameraViewController":
+             "CAMImagePickerCameraViewController",
+             "UIDocumentPickerViewController":
             return true
         case _ where topVCName.hasPrefix("ALK"):
             return true
         default:
             if let searchVC = topVC as? UISearchController,
-                searchVC.searchResultsController as? ALKSearchResultViewController != nil
+               searchVC.searchResultsController as? ALKSearchResultViewController != nil
             {
                 return true
             }

--- a/Sources/Utilities/NotificationHelper.swift
+++ b/Sources/Utilities/NotificationHelper.swift
@@ -122,9 +122,10 @@ public class NotificationHelper {
     ///   - notification: notification that is tapped.
     public func refreshConversation(_ viewController: ALKConversationViewController, with notification: NotificationData) {
         viewController.unsubscribingChannel()
-        if !self.isChatThreadIsOpen(notification,
-                                    userId: viewController.viewModel.contactId,
-                                    groupId: viewController.viewModel.channelKey) {
+        if !isChatThreadIsOpen(notification,
+                               userId: viewController.viewModel.contactId,
+                               groupId: viewController.viewModel.channelKey)
+        {
             viewController.viewModel.prefilledMessage = nil
         }
         viewController.viewModel.contactId = notification.userId
@@ -157,7 +158,7 @@ public class NotificationHelper {
             return true
         default:
             if let searchVC = topVC as? UISearchController,
-               searchVC.searchResultsController as? ALKSearchResultViewController != nil
+                searchVC.searchResultsController as? ALKSearchResultViewController != nil
             {
                 return true
             }

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -66,6 +66,8 @@ open class ALKConversationViewModel: NSObject, Localizable {
         }
         return true
     }
+    // Prefilled message for chatbox.
+    open var prefilledMessage: String?
 
     open var isContextBasedChat: Bool {
         guard conversationProxy == nil else { return true }
@@ -121,12 +123,14 @@ open class ALKConversationViewModel: NSObject, Localizable {
         contactId: String?,
         channelKey: NSNumber?,
         conversationProxy: ALConversationProxy? = nil,
-        localizedStringFileName: String!
+        localizedStringFileName: String!,
+        prefilledMessage: String? = nil
     ) {
         self.contactId = contactId
         self.channelKey = channelKey
         self.conversationProxy = conversationProxy
         self.localizedStringFileName = localizedStringFileName
+        self.prefilledMessage = prefilledMessage
     }
 
     // MARK: - Public methods

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -66,6 +66,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         }
         return true
     }
+
     // Prefilled message for chatbox.
     open var prefilledMessage: String?
 

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -706,6 +706,10 @@ open class ALKChatBar: UIView, Localizable {
             }
         }
     }
+
+    func setDefaultText(_ text: String) {
+        textView.text = text
+    }
 }
 
 extension ALKChatBar: UITextViewDelegate {


### PR DESCRIPTION
## Summary
* This is PR which will be used in KM SDK for adding the support for setting prefilled message before launching the chat and it will be used in the chatbox. 

* Added parameter **prefilledMessage** can be used to pass from Chatmanager.swift file during launching.



## Motivation
<!-- Why are you making this change? -->

## Testing
Tested with set the prefilled message and launch the chat and see if the text is showing in the chatbox.