### PR TITLE
Fix the UserInteraction not working in form cell for iOS 14 only! #trivial 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ## [Unreleased]
 
+### Fixes
+- Fixed issue where in form UI tap was not recognized in iOS 14.
+
 ## [5.10.0] - 2020-09-09
 
 ### Enhancements

--- a/Sources/Views/ALKBaseCell.swift
+++ b/Sources/Views/ALKBaseCell.swift
@@ -13,6 +13,7 @@ open class ALKBaseCell<T>: UITableViewCell {
     var viewModel: T?
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.isUserInteractionEnabled = true
         setupViews()
         setupStyle()
     }


### PR DESCRIPTION
Added the  contentView.isUserInteractionEnabled = true in base cell 

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
When I was working on the date picker I got to know that the form cell is not working any touches in iOS 14 works fine below iOS 14 

## Testing
Tested with ios 11 or ios 14 checked if the tap button or text fields are working or not in rich messages  works fine now.

  