### PR TITLE
[CM-402] Date picker support in form template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ### Enhancements
 - [CM-402] Date picker support in form template.
+- [CM-402] Text validation support in form template.
 
 ## [5.10.2] - 2020-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ## [Unreleased]
 
+### Enhancements
+- [CM-402] Date picker support in form template.
+
 ## [5.10.2] - 2020-10-06
 
 ### Fixes

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -494,6 +494,18 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                     self.activeTextField = textField
                 }
                 cell.update(viewModel: message)
+                cell.onTapOfDateSelect = { [weak self] index,
+                    delegate,
+                    datePickerMode,
+                    identifier in
+                    guard let weakSelf = self,
+                        let pickerButtonClickProtocol = delegate else { return }
+                    weakSelf.showDatePickerController(delegate: pickerButtonClickProtocol,
+                                                      identifier: identifier,
+                                                      position: index,
+                                                      datePickerMode: datePickerMode,
+                                                      localizedStringFileName: cell.localizedStringFileName)
+                }
                 return cell
             } else {
                 let cell: ALKFriendFormCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
@@ -508,6 +520,19 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                                                       messageModel: message,
                                                       isButtonClickDisabled:
                                                       weakSelf.configuration.disableRichMessageButtonAction)
+                }
+
+                cell.onTapOfDateSelect = { [weak self] index,
+                    delegate,
+                    datePickerMode,
+                    identifier in
+                    guard let weakSelf = self,
+                        let pickerButtonClickProtocol = delegate else { return }
+                    weakSelf.showDatePickerController(delegate: pickerButtonClickProtocol,
+                                                      identifier: identifier,
+                                                      position: index,
+                                                      datePickerMode: datePickerMode,
+                                                      localizedStringFileName: cell.localizedStringFileName)
                 }
                 return cell
             }

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -444,7 +444,6 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 if let filePath = message.filePath {
                     cell.updateContactDetails(key: message.identifier, filePath: filePath)
                 }
-                cell.setLocalizedStringFileName(configuration.localizedStringFileName)
                 if message.filePath == nil {
                     attachmentViewDidTapDownload(view: cell, indexPath: indexPath)
                 }
@@ -490,6 +489,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
             guard message.formTemplate() != nil else { return UITableViewCell() }
             if message.isMyMessage {
                 let cell: ALKMyFormCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
+                cell.setLocalizedStringFileName(configuration.localizedStringFileName)
                 cell.activeTextFieldChanged = { textField in
                     self.activeTextField = textField
                 }
@@ -497,6 +497,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 return cell
             } else {
                 let cell: ALKFriendFormCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
+                cell.setLocalizedStringFileName(configuration.localizedStringFileName)
                 cell.activeTextFieldChanged = { textField in
                     self.activeTextField = textField
                 }

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -516,10 +516,22 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 cell.update(viewModel: message)
                 cell.tapped = { [weak self] _, _, submitData in
                     guard let weakSelf = self else { return }
-                    weakSelf.formSubmitButtonSelected(formSubmitData: submitData,
-                                                      messageModel: message,
-                                                      isButtonClickDisabled:
-                                                      weakSelf.configuration.disableRichMessageButtonAction)
+
+                    // If not valid reload the table view section for a form to show the error message below the text fields.
+                    if !cell.isFormDataValid() {
+                        weakSelf.reloadSectionFor(identifier: message.identifier)
+                    } else {
+                        // The form data is valid to reload the existing form cell to remove error labels in the form.
+                        if let validationFields = submitData?.validationFields,
+                            !validationFields.isEmpty
+                        {
+                            weakSelf.reloadSectionFor(identifier: message.identifier)
+                        }
+                        weakSelf.formSubmitButtonSelected(formSubmitData: submitData,
+                                                          messageModel: message,
+                                                          isButtonClickDisabled:
+                                                          weakSelf.configuration.disableRichMessageButtonAction)
+                    }
                 }
 
                 cell.onTapOfDateSelect = { [weak self] index,
@@ -630,6 +642,16 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 cell.collectionView.setContentOffset(CGPoint(x: collectionViewOffsetFromIndex(index), y: 0), animated: false)
             }
         }
+    }
+
+    func reloadSectionFor(identifier: String) {
+        guard let index = viewModel.sectionFor(identifier: identifier),
+            index < tableView.numberOfSections
+        else {
+            print("Can't be updated form cell due to incorrect index")
+            return
+        }
+        tableView.reloadSections([index], with: .fade)
     }
 
     // MARK: Paging

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1512,8 +1512,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             }
         }
 
-        guard let viewModelItems = messageModel.formTemplate()?.viewModeItems
-        else { return }
+        let viewModelItems = formTemplate.viewModeItems
         for (pos, text) in formData.textFields {
             let element = viewModelItems[pos]
             switch element.type {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1132,7 +1132,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         let actualMessage = messageService.getALMessage(byKey: replyId).messageModel
         guard let indexPath = viewModel.getIndexpathFor(message: actualMessage)
         else {
-            let controller = ALKReplyController(userId: viewModel.contactId, groupId: viewModel.channelKey, messageKey: replyId, configuration: configuration)
+            let controller = ALKReplyController(messageKey: replyId, configuration: configuration)
             controller.modalPresentationStyle = .overCurrentContext
             present(controller, animated: true, completion: nil)
             return

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1705,6 +1705,21 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         guard message.messageType == .form else { return }
         updateMessageAt(indexPath: indexPath)
     }
+
+    func showDatePickerController(delegate: ALKDatePickerButtonClickProtocol,
+                                  identifier: String,
+                                  position: Int,
+                                  datePickerMode: UIDatePicker.Mode,
+                                  localizedStringFileName: String)
+    {
+        let datePickerVC = ALKFormDatePickerViewController(delegate: delegate,
+                                                           messageKey: identifier,
+                                                           position: position,
+                                                           datePickerMode: datePickerMode,
+                                                           localizedStringFileName: localizedStringFileName)
+        datePickerVC.modalPresentationStyle = .overCurrentContext
+        present(datePickerVC, animated: true, completion: nil)
+    }
 }
 
 extension ALKConversationViewController: CNContactPickerDelegate {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1469,7 +1469,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         guard let formData = formSubmitData,
             !formData.multiSelectFields.isEmpty ||
             !formData.textFields.isEmpty ||
-            !formData.singleSelectFields.isEmpty
+            !formData.singleSelectFields.isEmpty ||
+            !formData.dateFields.isEmpty
         else {
             print("Invalid empty form data for submit")
             return
@@ -1549,6 +1550,26 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
             let data = json(from: selectedArray)
             postFormData[multiSelect.name] = data
+        }
+
+        for (position, timeInMillSecs) in formData.dateFields {
+            let element = viewModelItems[position]
+            switch element.type {
+            case .time:
+                if let formViewModelTimeItem = element as? FormViewModelTimeItem {
+                    postFormData[formViewModelTimeItem.label] = String(timeInMillSecs)
+                }
+            case .date:
+                if let formViewModelDateItem = element as? FormViewModelDateItem {
+                    postFormData[formViewModelDateItem.label] = String(timeInMillSecs)
+                }
+            case .dateTimeLocal:
+                if let formViewModelDateTimeLocalItem = element as? FormViewModelDateTimeLocalItem {
+                    postFormData[formViewModelDateTimeLocalItem.label] = String(timeInMillSecs)
+                }
+            default:
+                break
+            }
         }
 
         guard let formJsonValue = ALUtilityClass.generateJsonString(from: postFormData) else {

--- a/Sources/Controllers/ALKFormDatePickerViewController.swift
+++ b/Sources/Controllers/ALKFormDatePickerViewController.swift
@@ -1,0 +1,209 @@
+//
+//  ALKFormDatePickerViewController.swift
+//  ApplozicSwift
+//
+//  Created by Sunil on 30/09/20.
+//
+
+import Foundation
+
+@objc protocol ALKDatePickerButtonClickProtocol {
+    func confirmButtonClick(position: Int, date: Date, messageKey: String, datePickerMode: UIDatePicker.Mode)
+}
+
+class ALKFormDatePickerViewController: UIViewController, Localizable {
+    public struct Padding {
+        struct ModelView {
+            static let left: CGFloat = 30.0
+            static let right: CGFloat = 30.0
+            static let bottomY: CGFloat = 50.0
+        }
+
+        struct TitleLabel {
+            static let top: CGFloat = 20.0
+            static let left: CGFloat = 10.0
+            static let right: CGFloat = 10.0
+        }
+
+        struct DatePickerView {
+            static let top: CGFloat = 20.0
+            static let left: CGFloat = 10.0
+            static let right: CGFloat = 10.0
+            static let bottom: CGFloat = 30.0
+        }
+
+        struct ButtonUIView {
+            static let height: CGFloat = 40.0
+            static let top: CGFloat = 10.0
+        }
+
+        struct CancelButton {
+            static let height: CGFloat = 40.0
+        }
+
+        struct ConfirmButton {
+            static let height: CGFloat = 40.0
+            static let left: CGFloat = 3.0
+        }
+    }
+
+    weak var delegate: ALKDatePickerButtonClickProtocol?
+    var action: String!
+    var messageKey: String!
+    var datePickerMode: UIDatePicker.Mode!
+    var localizedStringFileName: String!
+    var position: Int!
+
+    private let modalView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.white
+        view.layer.cornerRadius = 5
+        return view
+    }()
+
+    private let popupTitle: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.textColor = UIColor.black
+        label.numberOfLines = 3
+        label.font = Font.bold(size: 18.0).font()
+        return label
+    }()
+
+    private let uiDatePicker: UIDatePicker = {
+        let datePicker = UIDatePicker()
+        datePicker.autoresizingMask = .flexibleRightMargin
+        if #available(iOS 14.0, *) {
+            datePicker.preferredDatePickerStyle = .inline
+        } else if #available(iOS 13.4, *) {
+            datePicker.preferredDatePickerStyle = .compact
+        }
+        datePicker.date = Date()
+        return datePicker
+    }()
+
+    private lazy var confirmButton: UIButton = {
+        let button = UIButton()
+        let title = localizedString(forKey: "DoneButton", withDefaultValue: SystemMessage.ButtonName.Done,
+                                    fileName: localizedStringFileName).uppercased()
+        button.setTitle(title, for: .normal)
+        button.isUserInteractionEnabled = true
+        button.setTitleColor(UIView().tintColor, for: .normal)
+        button.setFont(font: Font.normal(size: 16.0).font())
+        button.setBackgroundColor(UIColor(red: 242.0 / 255.0, green: 242.0 / 255.0, blue: 242.0 / 255.0, alpha: 1.0))
+        return button
+    }()
+
+    private lazy var cancelButton: UIButton = {
+        let button = UIButton()
+        let title = localizedString(forKey: "CapitalLetterCancelText", withDefaultValue: SystemMessage.ButtonName.CapitalLetterCancelText,
+                                    fileName: localizedStringFileName)
+
+        button.setTitle(title, for: .normal)
+        button.isUserInteractionEnabled = true
+        button.setFont(font: Font.normal(size: 16.0).font())
+        button.setTitleColor(UIColor.black, for: .normal)
+        button.setBackgroundColor(UIColor(red: 242.0 / 255.0, green: 242.0 / 255.0, blue: 242.0 / 255.0, alpha: 1.0))
+        return button
+    }()
+
+    private let buttonUIView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 93.7, green: 93.7, blue: 93.7, alpha: 1.0)
+        return view
+    }()
+
+    init(delegate: ALKDatePickerButtonClickProtocol,
+         messageKey: String,
+         position: Int,
+         datePickerMode: UIDatePicker.Mode,
+         localizedStringFileName: String)
+    {
+        super.init(nibName: nil, bundle: nil)
+        self.delegate = delegate
+        self.messageKey = messageKey
+        self.position = position
+        self.datePickerMode = datePickerMode
+        self.localizedStringFileName = localizedStringFileName
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        addConstraints()
+        setupViews()
+    }
+
+    func addConstraints() {
+        view.addViewsForAutolayout(views: [modalView])
+        modalView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        modalView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -Padding.ModelView.bottomY).isActive = true
+        modalView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Padding.ModelView.left).isActive = true
+        modalView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Padding.ModelView.right).isActive = true
+
+        modalView.addViewsForAutolayout(views: [popupTitle,
+                                                uiDatePicker,
+                                                buttonUIView,
+                                                cancelButton,
+                                                confirmButton])
+        popupTitle.leadingAnchor.constraint(equalTo: modalView.leadingAnchor, constant: Padding.TitleLabel.left).isActive = true
+        popupTitle.trailingAnchor.constraint(equalTo: modalView.trailingAnchor, constant: -Padding.TitleLabel.right).isActive = true
+        popupTitle.topAnchor.constraint(equalTo: modalView.topAnchor, constant: Padding.TitleLabel.top).isActive = true
+
+        uiDatePicker.leadingAnchor.constraint(equalTo: modalView.leadingAnchor, constant: Padding.DatePickerView.left).isActive = true
+        uiDatePicker.trailingAnchor.constraint(equalTo: modalView.trailingAnchor, constant: -Padding.DatePickerView.right).isActive = true
+        uiDatePicker.topAnchor.constraint(equalTo: popupTitle.bottomAnchor, constant: Padding.DatePickerView.top).isActive = true
+        uiDatePicker.bottomAnchor.constraint(equalTo: modalView.bottomAnchor, constant: -Padding.DatePickerView.bottom).isActive = true
+
+        buttonUIView.heightAnchor.constraint(equalToConstant: Padding.ButtonUIView.height).isActive = true
+        buttonUIView.leadingAnchor.constraint(equalTo: modalView.leadingAnchor).isActive = true
+        buttonUIView.trailingAnchor.constraint(equalTo: modalView.trailingAnchor).isActive = true
+        buttonUIView.topAnchor.constraint(equalTo: uiDatePicker.bottomAnchor, constant: Padding.ButtonUIView.top).isActive = true
+
+        let halfWidth = (UIScreen.main.bounds.width - 60) / 2
+
+        cancelButton.heightAnchor.constraint(equalToConstant: Padding.CancelButton.height).isActive = true
+        cancelButton.leadingAnchor.constraint(equalTo: modalView.leadingAnchor).isActive = true
+        cancelButton.widthAnchor.constraint(equalToConstant: halfWidth).isActive = true
+        cancelButton.bottomAnchor.constraint(equalTo: buttonUIView.bottomAnchor).isActive = true
+
+        confirmButton.heightAnchor.constraint(equalToConstant: Padding.ConfirmButton.height).isActive = true
+        confirmButton.leadingAnchor.constraint(equalTo: cancelButton.trailingAnchor, constant: Padding.ConfirmButton.left).isActive = true
+        confirmButton.trailingAnchor.constraint(equalTo: buttonUIView.trailingAnchor).isActive = true
+        confirmButton.bottomAnchor.constraint(equalTo: buttonUIView.bottomAnchor).isActive = true
+
+        cancelButton.addTarget(self, action: #selector(tappedCancel), for: .touchUpInside)
+
+        confirmButton.addTarget(self, action: #selector(tappedConfirmButton), for: .touchUpInside)
+    }
+
+    func setupViews() {
+        view.backgroundColor = UIColor(10, green: 10, blue: 10, alpha: 0.2)
+        view.isOpaque = false
+        view.isUserInteractionEnabled = true
+        uiDatePicker.datePickerMode = datePickerMode
+        switch datePickerMode {
+        case .time:
+            popupTitle.text = "Select time"
+        case .date:
+            popupTitle.text = "Select date"
+        case .dateAndTime:
+            popupTitle.text = "Select date and time"
+        default:
+            popupTitle.text = "Select date"
+        }
+    }
+
+    @objc func tappedCancel() {
+        dismiss(animated: true, completion: nil)
+    }
+
+    @objc func tappedConfirmButton() {
+        delegate?.confirmButtonClick(position: position, date: uiDatePicker.date, messageKey: messageKey, datePickerMode: datePickerMode)
+        dismiss(animated: true, completion: nil)
+    }
+}

--- a/Sources/Controllers/ALKFormDatePickerViewController.swift
+++ b/Sources/Controllers/ALKFormDatePickerViewController.swift
@@ -12,7 +12,7 @@ import Foundation
 }
 
 class ALKFormDatePickerViewController: UIViewController, Localizable {
-    public struct Padding {
+    struct Padding {
         struct ModelView {
             static let left: CGFloat = 30.0
             static let right: CGFloat = 30.0
@@ -84,7 +84,8 @@ class ALKFormDatePickerViewController: UIViewController, Localizable {
 
     private lazy var confirmButton: UIButton = {
         let button = UIButton()
-        let title = localizedString(forKey: "DoneButton", withDefaultValue: SystemMessage.ButtonName.Done,
+        let title = localizedString(forKey: "DoneButton",
+                                    withDefaultValue: SystemMessage.ButtonName.Done,
                                     fileName: localizedStringFileName).uppercased()
         button.setTitle(title, for: .normal)
         button.isUserInteractionEnabled = true
@@ -96,9 +97,9 @@ class ALKFormDatePickerViewController: UIViewController, Localizable {
 
     private lazy var cancelButton: UIButton = {
         let button = UIButton()
-        let title = localizedString(forKey: "CapitalLetterCancelText", withDefaultValue: SystemMessage.ButtonName.CapitalLetterCancelText,
+        let title = localizedString(forKey: "CapitalLetterCancelText",
+                                    withDefaultValue: SystemMessage.ButtonName.CapitalLetterCancelText,
                                     fileName: localizedStringFileName)
-
         button.setTitle(title, for: .normal)
         button.isUserInteractionEnabled = true
         button.setFont(font: Font.normal(size: 16.0).font())
@@ -138,7 +139,7 @@ class ALKFormDatePickerViewController: UIViewController, Localizable {
         setupViews()
     }
 
-    func addConstraints() {
+    private func addConstraints() {
         view.addViewsForAutolayout(views: [modalView])
         modalView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         modalView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -Padding.ModelView.bottomY).isActive = true
@@ -181,29 +182,38 @@ class ALKFormDatePickerViewController: UIViewController, Localizable {
         confirmButton.addTarget(self, action: #selector(tappedConfirmButton), for: .touchUpInside)
     }
 
-    func setupViews() {
+    private func setupViews() {
         view.backgroundColor = UIColor(10, green: 10, blue: 10, alpha: 0.2)
         view.isOpaque = false
         view.isUserInteractionEnabled = true
         uiDatePicker.datePickerMode = datePickerMode
         switch datePickerMode {
         case .time:
-            popupTitle.text = "Select time"
+            popupTitle.text = localizedString(forKey: "DatePickerTimeTitle",
+                                              withDefaultValue: SystemMessage.LabelName.DatePickerTimeTitle,
+                                              fileName: localizedStringFileName)
         case .date:
-            popupTitle.text = "Select date"
+            popupTitle.text = localizedString(forKey: "DatePickerDateTitle",
+                                              withDefaultValue: SystemMessage.LabelName.DatePickerDateTitle,
+                                              fileName: localizedStringFileName)
         case .dateAndTime:
-            popupTitle.text = "Select date and time"
+            popupTitle.text = localizedString(forKey: "DatePickerDateAndTimeTitle",
+                                              withDefaultValue: SystemMessage.LabelName.DatePickerDateAndTimeTitle,
+                                              fileName: localizedStringFileName)
         default:
-            popupTitle.text = "Select date"
+            popupTitle.text = ""
         }
     }
 
-    @objc func tappedCancel() {
+    @objc private  func tappedCancel() {
         dismiss(animated: true, completion: nil)
     }
 
-    @objc func tappedConfirmButton() {
-        delegate?.confirmButtonClick(position: position, date: uiDatePicker.date, messageKey: messageKey, datePickerMode: datePickerMode)
+    @objc private  func tappedConfirmButton() {
+        delegate?.confirmButtonClick(position: position,
+                                     date: uiDatePicker.date,
+                                     messageKey: messageKey,
+                                     datePickerMode: datePickerMode)
         dismiss(animated: true, completion: nil)
     }
 }

--- a/Sources/Controllers/ALKFormDatePickerViewController.swift
+++ b/Sources/Controllers/ALKFormDatePickerViewController.swift
@@ -205,11 +205,11 @@ class ALKFormDatePickerViewController: UIViewController, Localizable {
         }
     }
 
-    @objc private  func tappedCancel() {
+    @objc private func tappedCancel() {
         dismiss(animated: true, completion: nil)
     }
 
-    @objc private  func tappedConfirmButton() {
+    @objc private func tappedConfirmButton() {
         delegate?.confirmButtonClick(position: position,
                                      date: uiDatePicker.date,
                                      messageKey: messageKey,

--- a/Sources/Controllers/ALKReplyController.swift
+++ b/Sources/Controllers/ALKReplyController.swift
@@ -72,8 +72,6 @@ class ALKReplyController: UIViewController, Localizable {
 
     let configuration: ALKConfiguration
     let messageKey: String
-    let userId: String?
-    let groupId: NSNumber?
 
     private let attachmentView = ALKAttatchmentView(frame: .zero)
 
@@ -143,9 +141,7 @@ class ALKReplyController: UIViewController, Localizable {
         return view
     }()
 
-    init(userId: String?, groupId: NSNumber?, messageKey: String, configuration: ALKConfiguration) {
-        self.userId = userId
-        self.groupId = groupId
+    init(messageKey: String, configuration: ALKConfiguration) {
         self.messageKey = messageKey
         self.configuration = configuration
         super.init(nibName: nil, bundle: nil)

--- a/Sources/Models/FormTemplate.swift
+++ b/Sources/Models/FormTemplate.swift
@@ -19,6 +19,7 @@ struct FormTemplate: Decodable {
         let label, placeholder, name, value, title, type: String?
         let action: Action?
         let options: [Option]?
+        let validation: Validation?
     }
 
     struct Option: Decodable {
@@ -27,6 +28,10 @@ struct FormTemplate: Decodable {
 
     struct Action: Decodable {
         let formAction, message, requestType: String?
+    }
+
+    struct Validation: Decodable {
+        let regex, errorText: String?
     }
 }
 

--- a/Sources/Models/FormTemplate.swift
+++ b/Sources/Models/FormTemplate.swift
@@ -46,6 +46,9 @@ extension FormTemplate.Element {
         case singleSelect = "radio"
         case hidden
         case submit
+        case date
+        case time
+        case dateTimeLocal = "datetime-local"
         case unknown
     }
 

--- a/Sources/Resources/Base.lproj/Localizable.strings
+++ b/Sources/Resources/Base.lproj/Localizable.strings
@@ -154,3 +154,6 @@ SpeechToTextPlaceholder = "(Go ahead, I'm listening)";
 DatePickerTimeTitle = "Select time";
 DatePickerDateTitle = "Select date";
 DatePickerDateAndTimeTitle = "Select date and time";
+
+/* Form UI*/
+InvalidDatErrorInForm = "Please enter valid data";

--- a/Sources/Resources/Base.lproj/Localizable.strings
+++ b/Sources/Resources/Base.lproj/Localizable.strings
@@ -150,3 +150,7 @@ FailedToLoadLink = "Failed to load a link";
 
 /* Speech to text */
 SpeechToTextPlaceholder = "(Go ahead, I'm listening)";
+
+DatePickerTimeTitle = "Select time";
+DatePickerDateTitle = "Select date";
+DatePickerDateAndTimeTitle = "Select date and time";

--- a/Sources/Utilities/ALKRegexValidator.swift
+++ b/Sources/Utilities/ALKRegexValidator.swift
@@ -1,0 +1,22 @@
+//
+//  ALKRegexValidator.swift
+//  ApplozicSwift
+//
+//  Created by Sunil on 07/10/20.
+//
+
+import Foundation
+
+struct ALKRegexValidator {
+    static func matchPattern(text: String, pattern: String) throws -> Bool {
+        let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+        do {
+            let regex = try NSRegularExpression(pattern: pattern, options: [])
+            let matches = regex.numberOfMatches(in: text, options: [], range: range)
+            print("Match for pattern found matches: \(matches)")
+            return matches > 0
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/Utilities/Date+Extension.swift
+++ b/Sources/Utilities/Date+Extension.swift
@@ -9,6 +9,23 @@
 import Foundation
 
 extension Date {
+    enum Formates {
+        enum Time {
+            static let twelve = "hh:mm a"
+            static let twentyfour = "HH:mm"
+        }
+
+        enum DateAndTime {
+            static let twelve = "dd/MM/yyyy, hh:mm a"
+            static let twentyfour = "MM/dd/yyyy, HH:mm"
+        }
+
+        enum Date {
+            static let twelve = "dd/MM/yyyy"
+            static let twentyfour = "MM/dd/yyyy"
+        }
+    }
+
     /**
      @abstract Example - Assuming today is Friday 20 September 2017, we would show:
      Today, Yesterday, Wednesday, Tuesday, Monday, Sunday, Fri, Feb 24, Jun 3, 2016 (for previous year), Etc.
@@ -39,5 +56,19 @@ extension Date {
         }
 
         return dateFormatter.string(from: self)
+    }
+
+    static func is24HrsFormate() -> Bool {
+        let formatter = DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: Locale.current)!
+        return !formatter.contains("a")
+    }
+
+    static func formatedDate(formateString: String,
+                             timeInMillSecs: Int64) -> String
+    {
+        let formatter = DateFormatter()
+        formatter.dateFormat = formateString
+        let date = Date(timeIntervalSince1970: TimeInterval(timeInMillSecs / 1000))
+        return formatter.string(from: date)
     }
 }

--- a/Sources/Utilities/NotificationHelper.swift
+++ b/Sources/Utilities/NotificationHelper.swift
@@ -67,10 +67,14 @@ public class NotificationHelper {
             let topVC = ALPushAssist().topViewController as? ALKConversationViewController,
             let viewModel = topVC.viewModel
         else {
-            guard let topVC = ALPushAssist().topViewController as? ALKReplyController else {
+            guard let topVC = ALPushAssist().topViewController,
+                let navVC = topVC.presentingViewController as? ALKBaseNavigationViewController,
+                let conversationViewController = navVC.topViewController as? ALKConversationViewController,
+                let viewModel = conversationViewController.viewModel
+            else {
                 return false
             }
-            return isChatThreadIsOpen(notification, userId: topVC.userId, groupId: topVC.groupId)
+            return isChatThreadIsOpen(notification, userId: viewModel.contactId, groupId: viewModel.channelKey)
         }
         return isChatThreadIsOpen(notification, userId: viewModel.contactId, groupId: viewModel.channelKey)
     }

--- a/Sources/Utilities/SystemMessage.swift
+++ b/Sources/Utilities/SystemMessage.swift
@@ -108,6 +108,7 @@ struct SystemMessage: Localizable {
 
     struct UIError {
         static let unspecifiedLocation = localizedString(forKey: "UnspecifiedLocation")
+        static let InvalidDatErrorInForm = localizedString(forKey: "InvalidDatErrorInForm")
     }
 
     struct PhotoAlbum {

--- a/Sources/Utilities/SystemMessage.swift
+++ b/Sources/Utilities/SystemMessage.swift
@@ -162,6 +162,9 @@ struct SystemMessage: Localizable {
         static let Report = localizedString(forKey: "Report")
         static let You = localizedString(forKey: "You")
         static let Admin = localizedString(forKey: "Admin")
+        static let DatePickerTimeTitle = localizedString(forKey: "DatePickerTimeTitle")
+        static let DatePickerDateTitle = localizedString(forKey: "DatePickerDateTitle")
+        static let DatePickerDateAndTimeTitle = localizedString(forKey: "DatePickerDateAndTimeTitle")
     }
 
     struct Mute {

--- a/Sources/ViewModels/ALKFormViewModelItem.swift
+++ b/Sources/ViewModels/ALKFormViewModelItem.swift
@@ -83,16 +83,22 @@ class FormViewModelMultiselectItem: FormViewModelItem {
 }
 
 class FormViewModelTextItem: FormViewModelItem {
+    typealias Validation = FormTemplate.Validation
     var type: FormViewModelItemType {
         return .text
     }
 
     let label: String
     let placeholder: String?
+    let validation: Validation?
 
-    init(label: String, placeholder: String?) {
+    init(label: String,
+         placeholder: String?,
+         validation: Validation?)
+    {
         self.label = label
         self.placeholder = placeholder
+        self.validation = validation
     }
 }
 
@@ -154,7 +160,8 @@ extension FormTemplate {
                     let placeHolder = elementData.placeholder else { return }
                 items.append(FormViewModelTextItem(
                     label: label,
-                    placeholder: placeHolder
+                    placeholder: placeHolder,
+                    validation: elementData.validation
                 ))
             case .password:
                 guard let elementData = element.data,

--- a/Sources/ViewModels/ALKFormViewModelItem.swift
+++ b/Sources/ViewModels/ALKFormViewModelItem.swift
@@ -12,6 +12,9 @@ enum FormViewModelItemType {
     case password
     case singleselect
     case multiselect
+    case date
+    case time
+    case dateTimeLocal
 }
 
 protocol FormViewModelItem {
@@ -107,6 +110,39 @@ class FormViewModelPasswordItem: FormViewModelItem {
     }
 }
 
+class FormViewModelDateItem: FormViewModelItem {
+    var type: FormViewModelItemType {
+        return .date
+    }
+
+    let label: String
+    init(label: String) {
+        self.label = label
+    }
+}
+
+class FormViewModelDateTimeLocalItem: FormViewModelItem {
+    var type: FormViewModelItemType {
+        return .dateTimeLocal
+    }
+
+    let label: String
+    init(label: String) {
+        self.label = label
+    }
+}
+
+class FormViewModelTimeItem: FormViewModelItem {
+    var type: FormViewModelItemType {
+        return .time
+    }
+
+    let label: String
+    init(label: String) {
+        self.label = label
+    }
+}
+
 extension FormTemplate {
     var viewModeItems: [FormViewModelItem] {
         var items: [FormViewModelItem] = []
@@ -144,6 +180,18 @@ extension FormTemplate {
                 items.append(FormViewModelMultiselectItem(name: name,
                                                           title: title,
                                                           options: options))
+            case .time:
+                guard let elementData = element.data,
+                    let label = elementData.label else { return }
+                items.append(FormViewModelTimeItem(label: label))
+            case .date:
+                guard let elementData = element.data,
+                    let label = elementData.label else { return }
+                items.append(FormViewModelDateItem(label: label))
+            case .dateTimeLocal:
+                guard let elementData = element.data,
+                    let label = elementData.label else { return }
+                items.append(FormViewModelDateTimeLocalItem(label: label))
             default:
                 print("\(element.contentType) form template type is not part of the form list view")
             }

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -61,42 +61,39 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
             return false
         }
         let item = items[textField.tag]
+        var formDatePickerViewController : ALKFormDatePickerViewController?
 
-        if item.type == .time {
-            let datePickerVC = ALKFormDatePickerViewController(delegate: self,
-                                                               messageKey: key,
-                                                               position: textField.tag,
-                                                               datePickerMode: .time,
-                                                               localizedStringFileName: localizedStringFileName)
-            let pushAssist = ALPushAssist()
-            let topVC = pushAssist.topViewController
-            datePickerVC.modalPresentationStyle = .overCurrentContext
-            topVC?.present(datePickerVC, animated: true, completion: nil)
-            return false
-        } else if item.type == .date {
-            let datePickerVC = ALKFormDatePickerViewController(delegate: self,
-                                                               messageKey: key,
-                                                               position: textField.tag,
-                                                               datePickerMode: .date,
-                                                               localizedStringFileName: localizedStringFileName)
-            let pushAssist = ALPushAssist()
-            let topVC = pushAssist.topViewController
-            datePickerVC.modalPresentationStyle = .overCurrentContext
-            topVC?.present(datePickerVC, animated: true, completion: nil)
-            return false
-        } else if item.type == .dateTimeLocal {
-            let datePickerVC = ALKFormDatePickerViewController(delegate: self,
-                                                               messageKey: key,
-                                                               position: textField.tag,
-                                                               datePickerMode: .dateAndTime,
-                                                               localizedStringFileName: localizedStringFileName)
-            let pushAssist = ALPushAssist()
-            let topVC = pushAssist.topViewController
-            datePickerVC.modalPresentationStyle = .overCurrentContext
-            topVC?.present(datePickerVC, animated: true, completion: nil)
-            return false
+        switch item.type {
+        case .time:
+            formDatePickerViewController = ALKFormDatePickerViewController(delegate: self,
+                                                                           messageKey: key,
+                                                                           position: textField.tag,
+                                                                           datePickerMode: .time,
+                                                                           localizedStringFileName: localizedStringFileName)
+        case .date:
+            formDatePickerViewController = ALKFormDatePickerViewController(delegate: self,
+                                                                           messageKey: key,
+                                                                           position: textField.tag,
+                                                                           datePickerMode: .date,
+                                                                           localizedStringFileName: localizedStringFileName)
+        case .dateTimeLocal:
+            formDatePickerViewController = ALKFormDatePickerViewController(delegate: self,
+                                                                           messageKey: key,
+                                                                           position: textField.tag,
+                                                                           datePickerMode: .dateAndTime,
+                                                                           localizedStringFileName: localizedStringFileName)
+        default:
+            return true
         }
-        return true
+
+        guard let datePickerVC = formDatePickerViewController,
+              let topVC = ALPushAssist().topViewController else {
+            return true
+        }
+
+        datePickerVC.modalPresentationStyle = .overCurrentContext
+        topVC.present(datePickerVC, animated: true, completion: nil)
+        return false
     }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
@@ -251,6 +248,8 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
                 let date = Date(timeIntervalSince1970: TimeInterval(timeInMillSecs / 1000))
                 let stringDate = formatter.string(from: date)
                 cell.valueTextField.text = stringDate
+            } else {
+                cell.valueTextField.text = ""
             }
             return cell
         case .time:
@@ -268,6 +267,8 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
                 let date = Date(timeIntervalSince1970: TimeInterval(timeInMillSecs / 1000))
                 let stringDate = formatter.string(from: date)
                 cell.valueTextField.text = stringDate
+            } else {
+                cell.valueTextField.text = ""
             }
             return cell
         case .dateTimeLocal:
@@ -286,6 +287,8 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
                 let date = Date(timeIntervalSince1970: TimeInterval(timeInMillSecs / 1000))
                 let stringDate = formatter.string(from: date)
                 cell.valueTextField.text = stringDate
+            } else {
+                cell.valueTextField.text = ""
             }
             return cell
         }

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -8,6 +8,11 @@
 import UIKit
 
 class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
+    enum FormData {
+        static let valid = 1
+        static let inValid = 2
+    }
+
     public var tapped: ((_ index: Int, _ name: String, _ formDataSubmit: FormDataSubmit?) -> Void)?
 
     public var onTapOfDateSelect: ((_ index: Int, _ delegate: ALKDatePickerButtonClickProtocol?, _ datePickerMode: UIDatePicker.Mode, _ identifier: String) -> Void)?
@@ -33,7 +38,7 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
         }
         set(newFormData) {
             guard let key = identifier,
-                let formData = newFormData else { return }
+                  let formData = newFormData else { return }
             formDataCacheStore.set(formData, for: key)
         }
     }
@@ -76,7 +81,7 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
         }
 
         guard let pickerMode = datePickerMode,
-            let dateSelectTap = onTapOfDateSelect
+              let dateSelectTap = onTapOfDateSelect
         else {
             return true
         }
@@ -92,8 +97,8 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
     func textFieldDidEndEditing(_ textField: UITextField) {
         activeTextField = nil
         guard let text = textField.text,
-            !text.trim().isEmpty,
-            let formSubmitData = formData
+              !text.trim().isEmpty,
+              let formSubmitData = formData
         else {
             if let data = formData {
                 data.textFields.removeValue(forKey: textField.tag)
@@ -152,12 +157,33 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
             cell.item = item
             cell.valueTextField.delegate = self
             cell.valueTextField.tag = indexPath.section
+            if let formDataSubmit = formData,
+               let text = formDataSubmit.textFields[indexPath.section]
+            {
+                cell.valueTextField.text = text
+            } else {
+                cell.valueTextField.text = ""
+            }
+            if let validationField = formData?.validationFields[indexPath.section], validationField == FormData.inValid {
+                let formViewModelTextItem = item as? FormViewModelTextItem
+                cell.errorLabel.text = formViewModelTextItem?.validation?.errorText ?? localizedString(forKey: "InvalidDatErrorInForm", withDefaultValue: SystemMessage.UIError.InvalidDatErrorInForm, fileName: localizedStringFileName)
+                cell.errorLabel.isHidden = false
+            } else {
+                cell.errorLabel.isHidden = true
+            }
             return cell
         case .password:
             let cell: ALKFormPasswordItemCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
             cell.item = item
             cell.valueTextField.delegate = self
             cell.valueTextField.tag = indexPath.section
+            if let formDataSubmit = formData,
+               let text = formDataSubmit.textFields[indexPath.section]
+            {
+                cell.valueTextField.text = text
+            } else {
+                cell.valueTextField.text = ""
+            }
             return cell
         case .singleselect:
             guard let singleselectItem = item as? FormViewModelSingleselectItem else {
@@ -178,8 +204,8 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
             cell.item = singleselectItem.options[indexPath.row]
 
             if let formDataSubmit = formData,
-                let singleSelectFields = formDataSubmit.singleSelectFields[indexPath.section],
-                singleSelectFields == indexPath.row
+               let singleSelectFields = formDataSubmit.singleSelectFields[indexPath.section],
+               singleSelectFields == indexPath.row
             {
                 cell.accessoryType = .checkmark
             } else {
@@ -214,7 +240,7 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
             }
 
             if let formDataSubmit = formData,
-                let multiSelectFields = formDataSubmit.multiSelectFields[indexPath.section], multiSelectFields.contains(indexPath.row)
+               let multiSelectFields = formDataSubmit.multiSelectFields[indexPath.section], multiSelectFields.contains(indexPath.row)
             {
                 cell.accessoryType = .checkmark
             } else {
@@ -319,8 +345,8 @@ extension ALKFormCell: ALKDatePickerButtonClickProtocol {
             break
         }
         guard let formSubmitData = formData,
-            timeInMillSecs > 0,
-            position < itemListView.numberOfSections
+              timeInMillSecs > 0,
+              position < itemListView.numberOfSections
         else {
             print("Can't be updated due to incorrect index")
             return
@@ -328,6 +354,43 @@ extension ALKFormCell: ALKDatePickerButtonClickProtocol {
         formSubmitData.dateFields[position] = timeInMillSecs
         formData = formSubmitData
         itemListView.reloadSections([position], with: .fade)
+    }
+}
+
+extension ALKFormCell {
+    func isFormDataValid() -> Bool {
+        var isValid: Bool = true
+
+        guard let formDataSubmit = formData,
+              let viewModelItems = template?.viewModeItems
+        else {
+            return false
+        }
+        // Loop and match all the text types for validation and mark them as valid or inValid.
+        for index in 0 ..< viewModelItems.count {
+            let element = viewModelItems[index]
+
+            switch element.type {
+            case .text:
+                let textFieldModel = element as? FormViewModelTextItem
+                let enteredText = formDataSubmit.textFields[index] ?? ""
+
+                if let validation = textFieldModel?.validation,
+                   let regxPattern = validation.regex
+                {
+                    do {
+                        isValid = try ALKRegexValidator.matchPattern(text: enteredText, pattern: regxPattern)
+                        formDataSubmit.validationFields[index] = isValid ? FormData.valid : FormData.inValid
+                        formData = formDataSubmit
+                    } catch {
+                        print("Error while matching text: \(error.localizedDescription)")
+                    }
+                }
+            default:
+                break
+            }
+        }
+        return isValid
     }
 }
 
@@ -349,4 +412,5 @@ class FormDataSubmit {
     var singleSelectFields = [Int: Int]()
     var multiSelectFields = [Int: [Int]]()
     var dateFields = [Int: Int64]()
+    var validationFields = [Int: Int]()
 }

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -5,11 +5,13 @@
 //  Created by Mukesh on 08/07/20.
 //
 
-import Applozic
 import UIKit
 
 class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
     public var tapped: ((_ index: Int, _ name: String, _ formDataSubmit: FormDataSubmit?) -> Void)?
+
+    public var onTapOfDateSelect: ((_ index: Int, _ delegate: ALKDatePickerButtonClickProtocol?, _ datePickerMode: UIDatePicker.Mode, _ identifier: String) -> Void)?
+
     let itemListView = NestedCellTableView()
     var submitButton: CurvedImageButton?
     var identifier: String?
@@ -61,38 +63,25 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate {
             return false
         }
         let item = items[textField.tag]
-        var formDatePickerViewController : ALKFormDatePickerViewController?
-
+        var datePickerMode: UIDatePicker.Mode?
         switch item.type {
         case .time:
-            formDatePickerViewController = ALKFormDatePickerViewController(delegate: self,
-                                                                           messageKey: key,
-                                                                           position: textField.tag,
-                                                                           datePickerMode: .time,
-                                                                           localizedStringFileName: localizedStringFileName)
+            datePickerMode = .time
         case .date:
-            formDatePickerViewController = ALKFormDatePickerViewController(delegate: self,
-                                                                           messageKey: key,
-                                                                           position: textField.tag,
-                                                                           datePickerMode: .date,
-                                                                           localizedStringFileName: localizedStringFileName)
+            datePickerMode = .date
         case .dateTimeLocal:
-            formDatePickerViewController = ALKFormDatePickerViewController(delegate: self,
-                                                                           messageKey: key,
-                                                                           position: textField.tag,
-                                                                           datePickerMode: .dateAndTime,
-                                                                           localizedStringFileName: localizedStringFileName)
+            datePickerMode = .dateAndTime
         default:
             return true
         }
 
-        guard let datePickerVC = formDatePickerViewController,
-              let topVC = ALPushAssist().topViewController else {
+        guard let pickerMode = datePickerMode,
+            let dateSelectTap = onTapOfDateSelect
+        else {
             return true
         }
 
-        datePickerVC.modalPresentationStyle = .overCurrentContext
-        topVC.present(datePickerVC, animated: true, completion: nil)
+        dateSelectTap(textField.tag, self, pickerMode, key)
         return false
     }
 
@@ -243,11 +232,8 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
             cell.valueTextField.delegate = self
             cell.valueTextField.tag = indexPath.section
             if let timeInMillSecs = formData?.dateFields[indexPath.section] {
-                let formatter = DateFormatter()
-                formatter.dateFormat = "dd-MM-yyyy"
-                let date = Date(timeIntervalSince1970: TimeInterval(timeInMillSecs / 1000))
-                let stringDate = formatter.string(from: date)
-                cell.valueTextField.text = stringDate
+                let dateFormate = Date.is24HrsFormate() ? Date.Formates.Date.twentyfour : Date.Formates.Date.twelve
+                cell.valueTextField.text = Date.formatedDate(formateString: dateFormate, timeInMillSecs: timeInMillSecs)
             } else {
                 cell.valueTextField.text = ""
             }
@@ -262,11 +248,8 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
             cell.valueTextField.tag = indexPath.section
 
             if let timeInMillSecs = formData?.dateFields[indexPath.section] {
-                let formatter = DateFormatter()
-                formatter.dateFormat = "hh:mm a"
-                let date = Date(timeIntervalSince1970: TimeInterval(timeInMillSecs / 1000))
-                let stringDate = formatter.string(from: date)
-                cell.valueTextField.text = stringDate
+                let timeFormate = Date.is24HrsFormate() ? Date.Formates.Time.twentyfour : Date.Formates.Time.twelve
+                cell.valueTextField.text = Date.formatedDate(formateString: timeFormate, timeInMillSecs: timeInMillSecs)
             } else {
                 cell.valueTextField.text = ""
             }
@@ -282,11 +265,8 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
             cell.valueTextField.tag = indexPath.section
 
             if let timeInMillSecs = formData?.dateFields[indexPath.section] {
-                let formatter = DateFormatter()
-                formatter.dateFormat = "dd-MM-yyyy hh:mm a"
-                let date = Date(timeIntervalSince1970: TimeInterval(timeInMillSecs / 1000))
-                let stringDate = formatter.string(from: date)
-                cell.valueTextField.text = stringDate
+                let dateTimeFromate = Date.is24HrsFormate() ? Date.Formates.DateAndTime.twentyfour : Date.Formates.DateAndTime.twelve
+                cell.valueTextField.text = Date.formatedDate(formateString: dateTimeFromate, timeInMillSecs: timeInMillSecs)
             } else {
                 cell.valueTextField.text = ""
             }

--- a/Sources/Views/ALKFormDateItemCell.swift
+++ b/Sources/Views/ALKFormDateItemCell.swift
@@ -1,0 +1,96 @@
+//
+//  ALKDateItemCell.swift
+//  ApplozicSwift
+//
+//  Created by Sunil on 30/09/20.
+//
+
+import Foundation
+import UIKit
+
+class ALKFormDateItemCell: ALKFormDateBaseCell {
+    var item: FormViewModelItem? {
+        didSet {
+            guard let item = item as? FormViewModelDateItem else {
+                return
+            }
+            nameLabel.text = item.label
+            valueTextField.attributedPlaceholder =
+                NSAttributedString(string: "dd-MM-yyyy")
+            valueTextField.placeholderColor = .lightGray
+        }
+    }
+}
+
+class ALKFormTimeItemCell: ALKFormDateBaseCell {
+    var item: FormViewModelItem? {
+        didSet {
+            guard let item = item as? FormViewModelTimeItem else {
+                return
+            }
+            nameLabel.text = item.label
+            valueTextField.attributedPlaceholder =
+                NSAttributedString(string: "hh:mm a")
+            valueTextField.placeholderColor = .lightGray
+        }
+    }
+}
+
+class ALKFormDateTimeItemCell: ALKFormDateBaseCell {
+    var item: FormViewModelItem? {
+        didSet {
+            guard let item = item as? FormViewModelDateTimeLocalItem else {
+                return
+            }
+            nameLabel.text = item.label
+            valueTextField.attributedPlaceholder =
+                NSAttributedString(string: "dd-MM-yyyy hh:mm a")
+            valueTextField.placeholderColor = .lightGray
+        }
+    }
+}
+
+class ALKFormDateBaseCell: UITableViewCell {
+    let nameLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.font = Font.medium(size: 15).font()
+        label.textColor = .black
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        return label
+    }()
+
+    let valueTextField: UITextField = {
+        let textfield = UITextField(frame: .zero)
+        textfield.isUserInteractionEnabled = true
+        return textfield
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        valueTextField.textColor = .black
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+        addConstraints()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func addConstraints() {
+        addViewsForAutolayout(views: [nameLabel, valueTextField])
+        nameLabel.layout {
+            $0.leading == leadingAnchor + 10
+            $0.trailing == trailingAnchor - 30
+            $0.top == topAnchor + 10
+        }
+        valueTextField.layout {
+            $0.leading == nameLabel.leadingAnchor
+            $0.trailing == nameLabel.trailingAnchor
+            $0.top == nameLabel.bottomAnchor + 5
+            $0.bottom <= bottomAnchor - 10
+        }
+    }
+}

--- a/Sources/Views/ALKFormDateItemCell.swift
+++ b/Sources/Views/ALKFormDateItemCell.swift
@@ -16,7 +16,7 @@ class ALKFormDateItemCell: ALKFormDateBaseCell {
             }
             nameLabel.text = item.label
             valueTextField.attributedPlaceholder =
-                NSAttributedString(string: "dd-MM-yyyy")
+                NSAttributedString(string: Date.is24HrsFormate() ? Date.Formates.Date.twentyfour : Date.Formates.Date.twelve)
             valueTextField.placeholderColor = .lightGray
         }
     }
@@ -30,7 +30,7 @@ class ALKFormTimeItemCell: ALKFormDateBaseCell {
             }
             nameLabel.text = item.label
             valueTextField.attributedPlaceholder =
-                NSAttributedString(string: "hh:mm a")
+                NSAttributedString(string: Date.is24HrsFormate() ? Date.Formates.Time.twentyfour : Date.Formates.Time.twelve)
             valueTextField.placeholderColor = .lightGray
         }
     }
@@ -44,7 +44,7 @@ class ALKFormDateTimeItemCell: ALKFormDateBaseCell {
             }
             nameLabel.text = item.label
             valueTextField.attributedPlaceholder =
-                NSAttributedString(string: "dd-MM-yyyy hh:mm a")
+                NSAttributedString(string: Date.is24HrsFormate() ? Date.Formates.DateAndTime.twentyfour : Date.Formates.DateAndTime.twelve)
             valueTextField.placeholderColor = .lightGray
         }
     }

--- a/Sources/Views/ALKFormTextItemCell.swift
+++ b/Sources/Views/ALKFormTextItemCell.swift
@@ -34,6 +34,23 @@ class ALKFormTextItemCell: UITableViewCell {
         return textfield
     }()
 
+    private lazy var errorStackView: UIStackView = {
+        let labelStackView = UIStackView()
+        labelStackView.axis = .horizontal
+        labelStackView.alignment = .fill
+        labelStackView.distribution = .fillEqually
+        labelStackView.backgroundColor = UIColor.white
+        return labelStackView
+    }()
+
+    let errorLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.textColor = .red
+        label.font = Font.normal(size: 15).font()
+        label.textAlignment = .left
+        return label
+    }()
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         valueTextField.textColor = .black
@@ -48,7 +65,9 @@ class ALKFormTextItemCell: UITableViewCell {
     }
 
     private func addConstraints() {
-        addViewsForAutolayout(views: [nameLabel, valueTextField])
+        addViewsForAutolayout(views: [nameLabel, valueTextField, errorStackView])
+        errorStackView.addArrangedSubview(errorLabel)
+        errorStackView.bringSubviewToFront(errorLabel)
         nameLabel.layout {
             $0.leading == leadingAnchor + 10
             $0.trailing == trailingAnchor - 30
@@ -58,6 +77,11 @@ class ALKFormTextItemCell: UITableViewCell {
             $0.leading == nameLabel.leadingAnchor
             $0.trailing == nameLabel.trailingAnchor
             $0.top == nameLabel.bottomAnchor + 5
+        }
+        errorStackView.layout {
+            $0.leading == nameLabel.leadingAnchor
+            $0.trailing == nameLabel.trailingAnchor
+            $0.top == valueTextField.bottomAnchor + 5
             $0.bottom <= bottomAnchor - 10
         }
     }


### PR DESCRIPTION
## Summary
This PR is a date picker implementation only.


Starting Form UI :

![IMG_0259](https://user-images.githubusercontent.com/11742961/95079295-08aa3b80-0734-11eb-9131-54939d2bd326.PNG)

iOS 14:

Date:

![IMG_0254](https://user-images.githubusercontent.com/11742961/95079229-f203e480-0733-11eb-9219-0ebd4c9a14a2.PNG)

Date and time.

![IMG_0261](https://user-images.githubusercontent.com/11742961/95079314-0fd14980-0734-11eb-979b-56edb65298ca.PNG)


iOS 13 and below:

![Simulator Screen Shot - iPhone 11 - 2020-10-05 at 18 06 37](https://user-images.githubusercontent.com/11742961/95080469-c5e96300-0735-11eb-970c-3ee3e30d5162.png)

![Simulator Screen Shot - iPhone 11 - 2020-10-05 at 18 06 19](https://user-images.githubusercontent.com/11742961/95080491-cc77da80-0735-11eb-9aa9-3f786ce47ade.png)


![Simulator Screen Shot - iPhone 11 - 2020-10-05 at 18 06 29](https://user-images.githubusercontent.com/11742961/95080485-caae1700-0735-11eb-91ff-83d906fc3f3d.png)


Selected values will be updated in form UI  after clicking on the `DONE` button 

![Simulator Screen Shot - iPhone 11 - 2020-10-05 at 18 25 01](https://user-images.githubusercontent.com/11742961/95082079-28436300-0738-11eb-9370-e009aaf89878.png)




## Motivation
## Testing
Tested with selecting a date , date-time, and time checked in the UI and also in the submit button tap.