### PR TITLE
Make sendQuickReply method open for accessing in KM #trivial

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1160,9 +1160,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         guard index < template.count, index >= 0 else { return }
         let dict = template[index]
         let metadata = dict["replyMetadata"] as? [String: Any]
-        let language = dict["updateLanguage"] as? String
+        let languageCode = dict["updateLanguage"] as? String
         /// Use metadata
-        sendQuickReply(title, metadata: metadata, language)
+        sendQuickReply(title, metadata: metadata, languageCode: languageCode)
     }
 
     func richButtonSelected(index: Int,
@@ -1187,8 +1187,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             submitButtonSelected(metadata: action, text: ackMessage)
         case "quickReply":
             let ackMessage = action["message"] as? String ?? title
-            let language = action["updateLanguage"] as? String
-            sendQuickReply(ackMessage, metadata: payload["replyMetadata"] as? [String: Any], language)
+            let languageCode = action["updateLanguage"] as? String
+            sendQuickReply(ackMessage, metadata: payload["replyMetadata"] as? [String: Any], languageCode: languageCode)
         default:
             print("Do nothing")
         }
@@ -1235,8 +1235,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         case ActionType.quickReply.rawValue:
             let text = action.text ?? defaultText
             guard let msg = text else { return }
-            let language = action.updateLanguage
-            sendQuickReply(msg, metadata: nil, language)
+            let languageCode = action.updateLanguage
+            sendQuickReply(msg, metadata: nil, languageCode: languageCode)
         default:
             print("Action type is neither \"link\" nor \"quick_reply\"")
             var infoDict = [String: Any]()
@@ -1275,8 +1275,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             submitButtonSelected(metadata: dict, text: payload.text ?? "")
         case CardTemplateActionType.quickReply.rawValue:
             let text = buttons[tag].action?.payload?.message ?? buttons[tag].name
-            let language = buttons[tag].action?.payload?.updateLanguage
-            sendQuickReply(text, metadata: nil, language)
+            let languageCode = buttons[tag].action?.payload?.updateLanguage
+            sendQuickReply(text, metadata: nil, languageCode: languageCode)
         default:
             /// Action not defined. Post notification outside.
             sendNotification(withName: "GenericRichCardButtonSelected", buttonName: title, buttonIndex: tag, template: message.payloadFromMetadata() ?? [], messageKey: message.identifier)
@@ -1364,7 +1364,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         isProfileTapActionEnabled = configuration.isProfileTapActionEnabled
     }
 
-    open func sendQuickReply(_ text: String, metadata: [String: Any]?, _: String?) {
+    open func sendQuickReply(_ text: String, metadata: [String: Any]?, languageCode _: String?) {
         var customMetadata = metadata ?? [String: Any]()
 
         guard let messageMetadata = configuration.messageMetadata as? [String: Any] else {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1160,9 +1160,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         guard index < template.count, index >= 0 else { return }
         let dict = template[index]
         let metadata = dict["replyMetadata"] as? [String: Any]
-
+        let language = dict["updateLanguage"] as? String
         /// Use metadata
-        sendQuickReply(title, metadata: metadata)
+        sendQuickReply(title, metadata: metadata, language)
     }
 
     func richButtonSelected(index: Int,
@@ -1187,7 +1187,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             submitButtonSelected(metadata: action, text: ackMessage)
         case "quickReply":
             let ackMessage = action["message"] as? String ?? title
-            sendQuickReply(ackMessage, metadata: payload["replyMetadata"] as? [String: Any])
+            let language = action["updateLanguage"] as? String
+            sendQuickReply(ackMessage, metadata: payload["replyMetadata"] as? [String: Any], language)
         default:
             print("Do nothing")
         }
@@ -1234,8 +1235,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         case ActionType.quickReply.rawValue:
             let text = action.text ?? defaultText
             guard let msg = text else { return }
-            sendQuickReply(msg, metadata: nil)
-
+            let language = action.updateLanguage
+            sendQuickReply(msg, metadata: nil, language)
         default:
             print("Action type is neither \"link\" nor \"quick_reply\"")
             var infoDict = [String: Any]()
@@ -1274,7 +1275,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             submitButtonSelected(metadata: dict, text: payload.text ?? "")
         case CardTemplateActionType.quickReply.rawValue:
             let text = buttons[tag].action?.payload?.message ?? buttons[tag].name
-            sendQuickReply(text, metadata: nil)
+            let language = buttons[tag].action?.payload?.updateLanguage
+            sendQuickReply(text, metadata: nil, language)
         default:
             /// Action not defined. Post notification outside.
             sendNotification(withName: "GenericRichCardButtonSelected", buttonName: title, buttonIndex: tag, template: message.payloadFromMetadata() ?? [], messageKey: message.identifier)
@@ -1362,7 +1364,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         isProfileTapActionEnabled = configuration.isProfileTapActionEnabled
     }
 
-    private func sendQuickReply(_ text: String, metadata: [String: Any]?) {
+    open func sendQuickReply(_ text: String, metadata: [String: Any]?, _: String?) {
         var customMetadata = metadata ?? [String: Any]()
 
         guard let messageMetadata = configuration.messageMetadata as? [String: Any] else {

--- a/Sources/Models/CardTemplate.swift
+++ b/Sources/Models/CardTemplate.swift
@@ -35,6 +35,7 @@ public struct CardTemplate: Codable {
         public let title: String?
         public let message: String?
         public let text: String?
+        public let updateLanguage: String?
         public let formAction: String?
         public let requestType: String?
         public let formData: CardTemplate.FormData?
@@ -54,7 +55,7 @@ public class Util {
         if let cardButtons = genericCard.buttons {
             buttons = [CardTemplate.Button]()
             for btn in cardButtons {
-                let payload = CardTemplate.Payload(url: nil, title: btn.name, message: btn.action, text: btn.data, formAction: nil, requestType: nil, formData: nil)
+                let payload = CardTemplate.Payload(url: nil, title: btn.name, message: btn.action, text: btn.data, updateLanguage: nil, formAction: nil, requestType: nil, formData: nil)
                 let action = CardTemplate.Action(type: "ALKGenericCard", payload: payload)
                 let button = CardTemplate.Button(name: btn.name, action: action)
                 buttons!.append(button)

--- a/Sources/Models/ListTemplateModel.swift
+++ b/Sources/Models/ListTemplateModel.swift
@@ -30,5 +30,6 @@ public struct ListTemplate: Codable {
         public let url: String?
         public let type: String?
         public let text: String?
+        public let updateLanguage: String?
     }
 }


### PR DESCRIPTION
## Summary
This PR will be used in KM SDK  [PR ](https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/pull/136)

* Open the sendQuickReply for overriding in KM SDK for sending language 
## Motivation
<!-- Why are you making this change? -->

## Testing
Tested in KM by using language bot to check if the  language is changed.