### PR TITLE
Fixed the issue conversation switching #trivial 📱 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ### Fixes
 - Fixed an issue where back button action in the conversation screen was not opening correct screen.
+- Fixed an issue where in some cases conversation was not switching when we open it through notification from background.
 
 ## [5.11.0] - 2020-10-27
 

--- a/Demo/ApplozicSwiftDemo/ALChatManager.swift
+++ b/Demo/ApplozicSwiftDemo/ALChatManager.swift
@@ -153,7 +153,7 @@ class ALChatManager: NSObject {
         }
         title = title.isEmpty ? "No name" : title
         let convViewModel = ALKConversationViewModel(contactId: contactId, channelKey: nil, localizedStringFileName: configuration.localizedStringFileName, prefilledMessage: prefilledMessage)
-        let conversationViewController = ALKConversationViewController(configuration: configuration)
+        let conversationViewController = ALKConversationViewController(configuration: configuration, individualLaunch: true)
         conversationViewController.viewModel = convViewModel
         launch(viewController: conversationViewController, from: viewController)
     }
@@ -163,7 +163,7 @@ class ALChatManager: NSObject {
         alChannelService.getChannelInformation(nil, orClientChannelKey: clientGroupId) { channel in
             guard let channel = channel, let key = channel.key else { return }
             let convViewModel = ALKConversationViewModel(contactId: nil, channelKey: key, localizedStringFileName: configuration.localizedStringFileName, prefilledMessage: prefilledMessage)
-            let conversationViewController = ALKConversationViewController(configuration: configuration)
+            let conversationViewController = ALKConversationViewController(configuration: configuration, individualLaunch: true)
             conversationViewController.viewModel = convViewModel
             self.launch(viewController: conversationViewController, from: viewController)
         }
@@ -174,7 +174,7 @@ class ALChatManager: NSObject {
         let userId = conversationProxy.userId
         let groupId = conversationProxy.groupId
         let convViewModel = ALKConversationViewModel(contactId: userId, channelKey: groupId, conversationProxy: conversationProxy, localizedStringFileName: configuration.localizedStringFileName)
-        let conversationViewController = ALKConversationViewController(configuration: configuration)
+        let conversationViewController = ALKConversationViewController(configuration: configuration, individualLaunch: true)
         conversationViewController.viewModel = convViewModel
         launch(viewController: conversationViewController, from: viewController)
     }

--- a/Demo/ApplozicSwiftDemoTests/Mocks/ALKConversationViewControllerMock.swift
+++ b/Demo/ApplozicSwiftDemoTests/Mocks/ALKConversationViewControllerMock.swift
@@ -13,8 +13,10 @@ class ALKConversationViewControllerMock: ALKConversationViewController {
     var testDisplayName: String!
     var onDeinitialized: (() -> Void)?
 
-    required init(configuration: ALKConfiguration) {
-        super.init(configuration: configuration)
+    override public init(configuration: ALKConfiguration,
+                         individualLaunch: Bool)
+    {
+        super.init(configuration: configuration, individualLaunch: individualLaunch)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListVCMemoryLeakTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListVCMemoryLeakTests.swift
@@ -19,7 +19,7 @@ class ALKConversationListVCMemoryLeakTests: QuickSpec {
             beforeEach {
                 waitUntil(timeout: 5.0) { done in
                     conversationListVC = ALKConversationListViewControllerMock(configuration: ALKConfiguration())
-                    let conversationVC = ALKConversationViewControllerMock(configuration: ALKConfiguration())
+                    let conversationVC = ALKConversationViewControllerMock(configuration: ALKConfiguration(), individualLaunch: true)
                     conversationVC.viewModel = ALKConversationViewModel(contactId: nil, channelKey: 000, localizedStringFileName: ALKConfiguration().localizedStringFileName)
                     let conversationListVM = ALKConversationListViewModel()
 

--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListViewControllerTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationListViewControllerTests.swift
@@ -46,7 +46,7 @@ class ALKConversationListViewControllerTests: XCTestCase {
         let selectItemExpectation = XCTestExpectation(description: "Conversation list item selected")
         let conversation = ConversationListTest()
         conversation.selectItemExpectation = selectItemExpectation
-        let conversationVC = ALKConversationViewControllerMock(configuration: ALKConfiguration())
+        let conversationVC = ALKConversationViewControllerMock(configuration: ALKConfiguration(), individualLaunch: true)
         conversationVC.viewModel = ALKConversationViewModelMock(contactId: nil, channelKey: 000, localizedStringFileName: ALKConfiguration().localizedStringFileName)
 
         // Pass all mocks

--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationVCMemoryLeakTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationVCMemoryLeakTests.swift
@@ -18,7 +18,7 @@ class ALKConversationVCMemoryLeakTests: QuickSpec {
         describe("when ALKConversationViewController is dismissed") {
             beforeEach {
                 waitUntil(timeout: 5.0) { done in
-                    conversationVC = ALKConversationViewControllerMock(configuration: ALKConfiguration())
+                    conversationVC = ALKConversationViewControllerMock(configuration: ALKConfiguration(), individualLaunch: true)
                     conversationVC?.viewModel = ALKConversationViewModel(contactId: "000", channelKey: nil, localizedStringFileName: ALKConfiguration().localizedStringFileName)
                     conversationVC?.contactService = ALContactServiceMock()
                     conversationVC?.onDeinitialized = {

--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationViewControllerSnapShotTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationViewControllerSnapShotTests.swift
@@ -20,7 +20,7 @@ class ALKConversationViewControllerSnapshotTests: QuickSpec {
 
             beforeEach {
                 let contactId = "testExample"
-                conversationVC = ALKConversationViewController(configuration: ALKConfiguration())
+                conversationVC = ALKConversationViewController(configuration: ALKConfiguration(), individualLaunch: true)
                 let convVM = ALKConversationViewModelMock(contactId: contactId, channelKey: nil, localizedStringFileName: ALKConfiguration().localizedStringFileName)
 
                 let firstMessage = MockMessage().message
@@ -102,7 +102,7 @@ class ALKConversationViewControllerSnapshotTests: QuickSpec {
             var navigationController: UINavigationController!
 
             func prepareController() {
-                conversationVC = ALKConversationViewController(configuration: configuration)
+                conversationVC = ALKConversationViewController(configuration: configuration, individualLaunch: true)
                 conversationVC.viewModel = ALKConversationViewModelMock(contactId: "demoUserId", channelKey: nil, localizedStringFileName: ALKConfiguration().localizedStringFileName)
                 conversationVC.beginAppearanceTransition(true, animated: false)
                 conversationVC.endAppearanceTransition()
@@ -148,7 +148,7 @@ class ALKConversationViewControllerSnapshotTests: QuickSpec {
             var navigationController: UINavigationController!
 
             beforeEach {
-                let conversationVC = ALKConversationViewController(configuration: ALKConfiguration())
+                let conversationVC = ALKConversationViewController(configuration: ALKConfiguration(), individualLaunch: true)
                 conversationVC.viewModel = ALKConversationViewModelMock(contactId: nil, channelKey: nil, localizedStringFileName: ALKConfiguration().localizedStringFileName)
                 conversationVC.beginAppearanceTransition(true, animated: false)
                 conversationVC.endAppearanceTransition()
@@ -167,7 +167,7 @@ class ALKConversationViewControllerSnapshotTests: QuickSpec {
 
             func prepareController(isSenderSide: Bool) {
                 let contactId = "testExample"
-                conversationVC = ALKConversationViewController(configuration: ALKConfiguration())
+                conversationVC = ALKConversationViewController(configuration: ALKConfiguration(), individualLaunch: true)
                 let convVM = ALKConversationViewModelMock(contactId: contactId, channelKey: nil, localizedStringFileName: ALKConfiguration().localizedStringFileName)
 
                 let emailMessage = MockMessage().message

--- a/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationViewControllerTests.swift
+++ b/Demo/ApplozicSwiftDemoTests/Tests/ALKConversationViewControllerTests.swift
@@ -15,7 +15,9 @@ class ALKConversationViewControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         conversationVC = ALKConversationViewController(
-            configuration: ALKConfiguration())
+            configuration: ALKConfiguration(),
+            individualLaunch: true
+        )
     }
 
     func testObserver_WhenInitializing() {
@@ -25,11 +27,7 @@ class ALKConversationViewControllerTests: XCTestCase {
 
             init(expectation: XCTestExpectation) {
                 rootExpectation = expectation
-                super.init(configuration: ALKConfiguration())
-            }
-
-            required init(configuration: ALKConfiguration) {
-                super.init(configuration: configuration)
+                super.init(configuration: ALKConfiguration(), individualLaunch: true)
             }
 
             required init?(coder aDecoder: NSCoder) {
@@ -46,7 +44,7 @@ class ALKConversationViewControllerTests: XCTestCase {
     }
 
     func testTypingStatusInGroup_UseDisplayName() {
-        let conversationVC = ALKConversationViewControllerMock(configuration: ALKConfiguration())
+        let conversationVC = ALKConversationViewControllerMock(configuration: ALKConfiguration(), individualLaunch: true)
         conversationVC.viewModel = ALKConversationViewModelMock(contactId: nil, channelKey: 000, localizedStringFileName: ALKConfiguration().localizedStringFileName)
         conversationVC.contactService = ALContactServiceMock()
         conversationVC.showTypingLabel(status: true, userId: "demoUserId")
@@ -56,7 +54,7 @@ class ALKConversationViewControllerTests: XCTestCase {
     func testTypingStatusInGroup_UseSomebody() {
         var configuration = ALKConfiguration()
         configuration.showNameWhenUserTypesInGroup = false
-        let conversationVC = ALKConversationViewControllerMock(configuration: configuration)
+        let conversationVC = ALKConversationViewControllerMock(configuration: configuration, individualLaunch: true)
         conversationVC.viewModel = ALKConversationViewModelMock(contactId: nil, channelKey: 000, localizedStringFileName: ALKConfiguration().localizedStringFileName)
         conversationVC.contactService = ALContactServiceMock()
         conversationVC.showTypingLabel(status: true, userId: "demoUserId")

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -294,7 +294,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
 
         let viewController: ALKConversationViewController!
         if conversationViewController == nil {
-            viewController = ALKConversationViewController(configuration: configuration)
+            viewController = ALKConversationViewController(configuration: configuration, individualLaunch: false)
             viewController.viewModel = conversationViewModel
         } else {
             viewController = conversationViewController
@@ -540,7 +540,7 @@ extension ALKConversationListViewController: ALKConversationListTableViewDelegat
         if let convId = chat.conversationId, let convProxy = convService.getConversationByKey(convId) {
             convViewModel.conversationProxy = convProxy
         }
-        let viewController = conversationViewController ?? ALKConversationViewController(configuration: configuration)
+        let viewController = conversationViewController ?? ALKConversationViewController(configuration: configuration, individualLaunch: false)
         viewController.viewModel = convViewModel
         viewController.individualLaunch = false
         navigationController?.pushViewController(viewController, animated: true)

--- a/Sources/Controllers/ALKCreateGroupViewController.swift
+++ b/Sources/Controllers/ALKCreateGroupViewController.swift
@@ -435,7 +435,7 @@ extension ALKCreateGroupViewController: ALKCreateGroupViewModelDelegate {
             localizedStringFileName: localizedStringFileName
         )
 
-        let conversationVC = ALKConversationViewController(configuration: configuration)
+        let conversationVC = ALKConversationViewController(configuration: configuration, individualLaunch: true)
         conversationVC.viewModel = conversationViewModel
         navigationController?.pushViewController(conversationVC, animated: true)
     }
@@ -573,7 +573,7 @@ extension ALKCreateGroupViewController: ALKAddParticipantProtocol {
             localizedStringFileName: localizedStringFileName
         )
 
-        let conversationVC = ALKConversationViewController(configuration: configuration)
+        let conversationVC = ALKConversationViewController(configuration: configuration, individualLaunch: true)
         conversationVC.viewModel = viewModel
         navigationController?.pushViewController(conversationVC, animated: true)
     }

--- a/Sources/Controllers/ALKNewChatViewController.swift
+++ b/Sources/Controllers/ALKNewChatViewController.swift
@@ -156,7 +156,7 @@ extension ALKNewChatViewController: UITableViewDelegate, UITableViewDataSource {
 
         let viewModel = ALKConversationViewModel(contactId: friendViewModel.friendUUID, channelKey: nil, localizedStringFileName: configuration.localizedStringFileName)
 
-        let conversationVC = ALKConversationViewController(configuration: configuration)
+        let conversationVC = ALKConversationViewController(configuration: configuration, individualLaunch: true)
         conversationVC.viewModel = viewModel
 
         launch(conversationVC, fromCreateGroup: false)
@@ -230,7 +230,7 @@ extension ALKNewChatViewController: ALKCreateGroupChatAddFriendProtocol {
             NotificationCenter.default.post(name: Notification.Name(rawValue: "reloadTable"), object: list)
 
             let viewModel = ALKConversationViewModel(contactId: nil, channelKey: alChannel.key, localizedStringFileName: self.configuration.localizedStringFileName)
-            let conversationVC = ALKConversationViewController(configuration: self.configuration)
+            let conversationVC = ALKConversationViewController(configuration: self.configuration, individualLaunch: true)
             conversationVC.viewModel = viewModel
             self.launch(conversationVC, fromCreateGroup: true)
             self.tableView.isUserInteractionEnabled = true

--- a/Sources/Controllers/ALKSearchResultViewController.swift
+++ b/Sources/Controllers/ALKSearchResultViewController.swift
@@ -101,7 +101,7 @@ extension ALKSearchResultViewController: ALKConversationListTableViewDelegate {
         )
         convViewModel.isSearch = true
 
-        let viewController = conversationViewController ?? ALKConversationViewController(configuration: configuration)
+        let viewController = conversationViewController ?? ALKConversationViewController(configuration: configuration, individualLaunch: false)
         viewController.viewModel = convViewModel
         viewController.individualLaunch = false
         conversationViewController = viewController


### PR DESCRIPTION
##  Summary
Fixed the issue where launching chat using methods and keeping the app in the background and clicking on APNS notification the chat was not switching to another conversation if we sent a message from different users or groups.

Made the pushNotification as open can be used in kommunicate to override and handle the refresh this is kommunicate PR which we had fixed the same issue their : https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/pull/108


Will create another PR in kommunicate SDK that will have change for overriding   this `pushNotification` and calling the conversation VC to init with `individual` flag  

## Motivation
There was an issue when we launch the chat using `launchChatWith(contactId: or launchChatWith(clientGroupId:` using `ALChatManager` keeping the app in the background the conversation was not switching

## Testing
Tested this issue and basics in the app.