### PR TITLE
[CM-486] Show time, state and correct padding in 'All buttons' rich message template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ## [Unreleased]
 
+### Enhancements
+- [CM-486] Show time, state and correct message view's left padding in the all buttons rich message template.
+
 ## [5.11.0] - 2020-10-27
 
 ### Enhancements
 - [CM-402] Date picker support in form template.
 - [CM-402] Text validation support in form template.
 - [CM-451] Add support for setting a prefilled message to send before launching a chat.
-<<<<<<< HEAD
 - [CM-480] Added config for changing textview's text and placeholder style
  </br> Use the below config to change the style:
 
@@ -22,9 +24,7 @@ ALKChatBarConfiguration.TextView.placeholder = Style(font: .font(.normal(size: 1
 // Text view's text style
 ALKChatBarConfiguration.TextView.text = Style(font: .font(.normal(size: 18)), text: .black)
 ```
-=======
 - [CM-411] Show new Photos UI in iOS 14+ devices to send images/videos without giving full access to the library.
->>>>>>> Add config to enable photos UI
 
 ## [5.10.2] - 2020-10-06
 

--- a/RichMessageKit/Utilities/QuickReplyConfig.swift
+++ b/RichMessageKit/Utilities/QuickReplyConfig.swift
@@ -10,19 +10,19 @@ struct ChatCellPadding {
     struct SentMessage {
         struct Message {
             static let left: CGFloat = 95
-            static let right: CGFloat = 25
+            static let right: CGFloat = 10
         }
 
         struct QuickReply {
             static let left: CGFloat = 75
             static let top: CGFloat = 5
-            static let right: CGFloat = 25
+            static let right: CGFloat = 10
             static let bottom: CGFloat = 5
         }
 
         struct MessageButton {
             static let left: CGFloat = 75
-            static let right: CGFloat = 25
+            static let right: CGFloat = 10
             static let top: CGFloat = 5
             static let bottom: CGFloat = 5
         }

--- a/RichMessageKit/Views/SentButtonsCell.swift
+++ b/RichMessageKit/Views/SentButtonsCell.swift
@@ -10,31 +10,56 @@ import Foundation
 public class SentButtonsCell: UITableViewCell {
     // MARK: - Public properties
 
-    public struct Config {
-        public static var buttonTopPadding: CGFloat = 4
-        public static var padding = Padding(left: 60, right: 10, top: 10, bottom: 10)
-        public static var maxWidth = UIScreen.main.bounds.width
-        public static var buttonWidth = maxWidth - (padding.left + padding.right)
+    enum ViewPadding {
+        enum StateView {
+            static let bottom: CGFloat = 3
+            static let right: CGFloat = 2
+            static let height: CGFloat = 9
+            static let width: CGFloat = 17
+        }
+
+        enum TimeLabel {
+            static let right: CGFloat = 2
+            static let left: CGFloat = 2
+            static let bottom: CGFloat = 2
+            static let maxWidth: CGFloat = 200
+        }
+
+        static let maxWidth = UIScreen.main.bounds.width
+        static let messageViewPadding = Padding(left: ChatCellPadding.SentMessage.Message.left,
+                                                right: ChatCellPadding.SentMessage.Message.right,
+                                                top: 0,
+                                                bottom: 0)
     }
 
     // MARK: - Fileprivate properties
 
+    fileprivate var timeLabel: UILabel = {
+        let lb = UILabel()
+        lb.isOpaque = true
+        return lb
+    }()
+
+    fileprivate var stateView: UIImageView = {
+        let sv = UIImageView()
+        sv.isUserInteractionEnabled = false
+        sv.contentMode = .center
+        return sv
+    }()
+
     fileprivate lazy var buttons = SuggestedReplyView()
-    fileprivate lazy var messageView = SentMessageView(
-        frame: .zero,
-        padding: messageViewPadding,
-        maxWidth: Config.maxWidth
+    fileprivate lazy var messageView = MessageView(
+        bubbleStyle: MessageTheme.sentMessage.bubble,
+        messageStyle: MessageTheme.sentMessage.message,
+        maxWidth: ViewPadding.maxWidth
     )
     fileprivate lazy var messageViewHeight = messageView.heightAnchor.constraint(equalToConstant: 0)
-    fileprivate var messageViewPadding: Padding
+    fileprivate lazy var timeLabelWidth = timeLabel.widthAnchor.constraint(equalToConstant: 0)
+    fileprivate lazy var timeLabelHeight = timeLabel.heightAnchor.constraint(equalToConstant: 0)
 
     // MARK: - Initializer
 
     override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        messageViewPadding = Padding(left: Config.padding.left,
-                                     right: Config.padding.right,
-                                     top: Config.padding.top,
-                                     bottom: Config.buttonTopPadding)
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupConstraints()
         backgroundColor = .clear
@@ -54,13 +79,32 @@ public class SentButtonsCell: UITableViewCell {
             print("For SentMessage value of isMyMessage should be true")
             return
         }
-        messageView.update(model: model.message)
-        messageViewHeight.constant = SentMessageView.rowHeight(
-            model: model.message,
-            maxWidth: Config.maxWidth,
-            padding: messageViewPadding
+        let isMessageEmpty = model.message.isMessageEmpty()
+        messageViewHeight.constant = isMessageEmpty ? 0 : SentMessageViewSizeCalculator().rowHeight(messageModel: model.message,
+                                                      maxWidth: ViewPadding.maxWidth,
+                                                      padding: ViewPadding.messageViewPadding)
+        if !isMessageEmpty {
+            messageView.update(model: model.message)
+        }
+
+        messageView.updateHeighOfView(hideView: isMessageEmpty, model: model.message)
+
+        let buttonsWidth = ViewPadding.maxWidth -
+            (ChatCellPadding.SentMessage.QuickReply.left + ChatCellPadding.SentMessage.QuickReply.right)
+        buttons.update(model: model, maxWidth: buttonsWidth)
+
+        // Set time
+        timeLabel.text = model.message.time
+        timeLabel.setStyle(ALKMessageStyle.time)
+
+        let timeLabelSize = model.message.time.rectWithConstrainedWidth(
+            ViewPadding.TimeLabel.maxWidth,
+            font: ALKMessageStyle.time.font
         )
-        buttons.update(model: model, maxWidth: Config.buttonWidth)
+
+        timeLabelHeight.constant = timeLabelSize.height.rounded(.up)
+        timeLabelWidth.constant = timeLabelSize.width.rounded(.up)
+        setStatusStyle(model: model, statusView: stateView, ALKMessageStyle.messageStatus)
     }
 
     /// It is used to get exact height of `SentButtonsCell` using messageModel, width and padding
@@ -69,28 +113,89 @@ public class SentButtonsCell: UITableViewCell {
     ///   - model: object that conforms to `SuggestedReplyMessage`
     /// - Returns: exact height of the view.
     public static func rowHeight(model: SuggestedReplyMessage) -> CGFloat {
-        let messageViewPadding = Padding(left: Config.padding.left,
-                                         right: Config.padding.right,
-                                         top: Config.padding.top,
-                                         bottom: Config.buttonTopPadding)
-        let messageHeight = SentMessageView.rowHeight(model: model.message, maxWidth: Config.maxWidth, padding: messageViewPadding)
-        let buttonHeight = SuggestedReplyView.rowHeight(model: model, maxWidth: Config.buttonWidth)
-        return messageHeight + buttonHeight + Config.padding.bottom
+        var height: CGFloat = 0
+        let isMessageEmpty = model.message.isMessageEmpty()
+
+        let timeLabelSize = model.message.time.rectWithConstrainedWidth(
+            ViewPadding.TimeLabel.maxWidth,
+            font: ALKMessageStyle.time.font
+        )
+
+        if !isMessageEmpty {
+            height = SentMessageViewSizeCalculator().rowHeight(messageModel: model.message,
+                                                               maxWidth: ViewPadding.maxWidth,
+                                                               padding: ViewPadding.messageViewPadding)
+        }
+
+        let quickReplyViewWidth = ViewPadding.maxWidth -
+            (ChatCellPadding.SentMessage.QuickReply.left + ChatCellPadding.SentMessage.QuickReply.right)
+
+        return height
+            + SuggestedReplyView.rowHeight(model: model, maxWidth: quickReplyViewWidth)
+            + ChatCellPadding.SentMessage.QuickReply.top
+            + ChatCellPadding.SentMessage.QuickReply.bottom + timeLabelSize.height.rounded(.up) + ViewPadding.TimeLabel.bottom
     }
 
     private func setupConstraints() {
-        addViewsForAutolayout(views: [messageView, buttons])
-
+        addViewsForAutolayout(views: [messageView, buttons, stateView, timeLabel])
         NSLayoutConstraint.activate([
-            messageView.topAnchor.constraint(equalTo: topAnchor),
-            messageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            messageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            messageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            messageView.leadingAnchor.constraint(
+                greaterThanOrEqualTo: contentView.leadingAnchor,
+                constant: ChatCellPadding.SentMessage.Message.left
+            ),
+            messageView.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -ChatCellPadding.SentMessage.Message.right
+            ),
             messageViewHeight,
-
-            buttons.topAnchor.constraint(equalTo: messageView.bottomAnchor, constant: 0),
-            buttons.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Config.padding.right),
-            buttons.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
-            buttons.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -1 * Config.padding.bottom),
+            buttons.topAnchor.constraint(
+                equalTo: messageView.bottomAnchor,
+                constant: ChatCellPadding.SentMessage.QuickReply.top
+            ),
+            buttons.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -ChatCellPadding.SentMessage.QuickReply.right
+            ),
+            buttons.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: ChatCellPadding.SentMessage.QuickReply.left),
+            buttons.bottomAnchor.constraint(
+                equalTo: timeLabel.topAnchor,
+                constant: -ChatCellPadding.SentMessage.QuickReply.bottom
+            ),
+            stateView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -1 * ViewPadding.StateView.bottom),
+            stateView.trailingAnchor.constraint(equalTo: buttons.trailingAnchor, constant: -1 * ViewPadding.StateView.right),
+            stateView.heightAnchor.constraint(equalToConstant: ViewPadding.StateView.height),
+            stateView.widthAnchor.constraint(equalToConstant: ViewPadding.StateView.width),
+            timeLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -1 * ViewPadding.TimeLabel.bottom),
+            timeLabel.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: ViewPadding.TimeLabel.left),
+            timeLabelWidth,
+            timeLabelHeight,
+            timeLabel.trailingAnchor.constraint(equalTo: stateView.leadingAnchor, constant: -1 * ViewPadding.TimeLabel.right),
         ])
+    }
+
+    func setStatusStyle(
+        model: SuggestedReplyMessage,
+        statusView: UIImageView,
+        _ style: ALKMessageStyle.SentMessageStatus,
+        _ size: CGSize = CGSize(width: 17, height: 9)
+    ) {
+        guard let status = model.message.status,
+              let statusIcon = style.statusIcons[status] else { return }
+        switch statusIcon {
+        case let .templateImageWithTint(image, tintColor):
+            statusView.image = image
+                .imageFlippedForRightToLeftLayoutDirection()
+                .scale(with: size)?
+                .withRenderingMode(.alwaysTemplate)
+            statusView.tintColor = tintColor
+        case let .normalImage(image):
+            statusView.image = image
+                .imageFlippedForRightToLeftLayoutDirection()
+                .scale(with: size)?
+                .withRenderingMode(.alwaysOriginal)
+        case .none:
+            statusView.image = nil
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Now, time and message state will be shown in the sender side view of all buttons rich message template.
- Also, used the new message view and corrected message view's left padding.

## Motivation
To match the sender side view to the receiver side.

## Testing
- By checking the UI of some of the previous messages.

### Screenshots:

*Before:*
![Simulator Screen Shot - iPhone 11 - 2020-11-02 at 14 44 05](https://user-images.githubusercontent.com/5956714/97850455-11cdfe80-1d1a-11eb-8d11-fcbd7a9f25ee.png)

----

*After:*

![Simulator Screen Shot - iPhone 11 - 2020-11-02 at 16 33 50](https://user-images.githubusercontent.com/5956714/97861478-dcc9a800-1d29-11eb-886d-026e19c7132e.png)
