### PR TITLE
Fix for wrong back stack in nav for group create #trivial 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - [CM-486] Show time, state and correct message view's left padding in the all buttons rich message template.
 - [CM-507] Enable screen transition animations in all screens.
 
+### Fixes
+- Fixed an issue where group create navigation back stack was misconfigured.
+
 ## [5.11.0] - 2020-10-27
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 - [CM-507] Enable screen transition animations in all screens.
 
 ### Fixes
-- Fixed an issue where group create navigation back stack was misconfigured.
+- Fixed an issue where back button action in the conversation screen was not opening correct screen.
 
 ## [5.11.0] - 2020-10-27
 

--- a/RichMessageKit/Views/SentButtonsCell.swift
+++ b/RichMessageKit/Views/SentButtonsCell.swift
@@ -81,8 +81,8 @@ public class SentButtonsCell: UITableViewCell {
         }
         let isMessageEmpty = model.message.isMessageEmpty()
         messageViewHeight.constant = isMessageEmpty ? 0 : SentMessageViewSizeCalculator().rowHeight(messageModel: model.message,
-                                                      maxWidth: ViewPadding.maxWidth,
-                                                      padding: ViewPadding.messageViewPadding)
+                                                                                                    maxWidth: ViewPadding.maxWidth,
+                                                                                                    padding: ViewPadding.messageViewPadding)
         if !isMessageEmpty {
             messageView.update(model: model.message)
         }
@@ -181,7 +181,7 @@ public class SentButtonsCell: UITableViewCell {
         _ size: CGSize = CGSize(width: 17, height: 9)
     ) {
         guard let status = model.message.status,
-              let statusIcon = style.statusIcons[status] else { return }
+            let statusIcon = style.statusIcons[status] else { return }
         switch statusIcon {
         case let .templateImageWithTint(image, tintColor):
             statusView.image = image

--- a/Sources/Controllers/ALKNewChatViewController.swift
+++ b/Sources/Controllers/ALKNewChatViewController.swift
@@ -108,9 +108,11 @@ public final class ALKNewChatViewController: ALKBaseViewController, Localizable 
         tableView.register(ALKFriendNewChatCell.self)
     }
 
-    private func launch(_ conversationVC: ALKConversationViewController) {
-        // Remove current VC from the stack
-        var navControllers = navigationController?.viewControllers.dropLast() ?? []
+    private func launch(_ conversationVC: ALKConversationViewController, fromCreateGroup: Bool) {
+        // Remove the last 3 VC from the stack in case of fromCreateGroup is true
+        // If fromCreateGroup false remove last VC
+        // and ALKConversationViewController
+        var navControllers = navigationController?.viewControllers.dropLast(fromCreateGroup ? 3 : 1) ?? []
         navControllers.append(conversationVC)
         navigationController?.setViewControllers(navControllers, animated: true)
     }
@@ -157,7 +159,7 @@ extension ALKNewChatViewController: UITableViewDelegate, UITableViewDataSource {
         let conversationVC = ALKConversationViewController(configuration: configuration)
         conversationVC.viewModel = viewModel
 
-        launch(conversationVC)
+        launch(conversationVC, fromCreateGroup: false)
         self.tableView.deselectRow(at: indexPath, animated: true)
         self.tableView.isUserInteractionEnabled = true
     }
@@ -230,8 +232,7 @@ extension ALKNewChatViewController: ALKCreateGroupChatAddFriendProtocol {
             let viewModel = ALKConversationViewModel(contactId: nil, channelKey: alChannel.key, localizedStringFileName: self.configuration.localizedStringFileName)
             let conversationVC = ALKConversationViewController(configuration: self.configuration)
             conversationVC.viewModel = viewModel
-            _ = self.navigationController?.popToViewController(self, animated: true)
-            self.launch(conversationVC)
+            self.launch(conversationVC, fromCreateGroup: true)
             self.tableView.isUserInteractionEnabled = true
         })
     }

--- a/Sources/Controllers/ALKNewChatViewController.swift
+++ b/Sources/Controllers/ALKNewChatViewController.swift
@@ -111,7 +111,7 @@ public final class ALKNewChatViewController: ALKBaseViewController, Localizable 
     private func launch(_ conversationVC: ALKConversationViewController, fromCreateGroup: Bool) {
         // Remove the last 3 VC from the stack in case of fromCreateGroup is true
         // If fromCreateGroup false remove last VC
-        // and ALKConversationViewController
+        // and Add ALKConversationViewController
         var navControllers = navigationController?.viewControllers.dropLast(fromCreateGroup ? 3 : 1) ?? []
         navControllers.append(conversationVC)
         navigationController?.setViewControllers(navControllers, animated: true)


### PR DESCRIPTION
## Summary
There was an issue when we create a group after clicking on back in chat list screen  navigation bar it was going to add member VC 

## Motivation
<!-- Why are you making this change? -->

## Testing
checked by group create 