### PR TITLE
Apply chat bar attachment color to the bottom part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ### Enhancements
 
 - Added an option to show/hide different message menu options.
+- Now, chat bar's attachment color config will be applied to the bottom part of the chat bar as well.
 
 ## [5.11.1] - 2020-12-01
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -708,7 +708,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         chatBar.grayView.backgroundColor = configuration.backgroundColor
 
         // Update background view's color which contains all the attachment options.
-        chatBar.bottomGrayView.backgroundColor = configuration.chatBarAttachmentViewBackgroundColor
+        chatBar.bottomBackgroundColor = configuration.chatBarAttachmentViewBackgroundColor
 
         chatBar.poweredByMessageLabel.attributedText =
             NSAttributedString(string: "Powered by Applozic")

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -294,6 +294,12 @@ open class ALKChatBar: UIView, Localizable {
     private weak var comingSoonDelegate: UIView?
 
     var chatIdentifier: String?
+    var bottomBackgroundColor: UIColor = .background(.grayEF) {
+        didSet {
+            bottomGrayView.backgroundColor = bottomBackgroundColor
+            backgroundColor = bottomBackgroundColor
+        }
+    }
 
     private func initializeView() {
         if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
@@ -304,7 +310,8 @@ open class ALKChatBar: UIView, Localizable {
         soundRec.setAudioRecViewDelegate(recorderDelegate: self)
         textView.typingAttributes = defaultTextAttributes
         textView.add(delegate: self)
-        backgroundColor = .background(.grayEF)
+        bottomGrayView.backgroundColor = bottomBackgroundColor
+        backgroundColor = bottomBackgroundColor
         translatesAutoresizingMaskIntoConstraints = false
 
         plusButton.addTarget(self, action: #selector(tapped(button:)), for: .touchUpInside)


### PR DESCRIPTION
## Summary
- Used chat bar's attachment color config in the bottom part(safe area) of the chat bar as well.
- Earlier this config option was just used for the attachment part, but there was no way to change the color of the safe area below that. So, used the same color for the safe area.

## Motivation
To change the color of the bottom part of the safe area from outside.

## Testing
Tested in the default color(gray) and by changing the color like this:
```swift
config.chatBarAttachmentViewBackgroundColor = .cyan
```

Screenshot: 
![Simulator Screen Shot - iPhone 11 - 2021-01-13 at 19 07 24](https://user-images.githubusercontent.com/5956714/104459337-9cf92980-55d2-11eb-82c1-29261674d2d9.png)
