### PR TITLE
Fix message truncation issue in quick reply and form template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 ## [Unreleased]
 
+### Fixes
+
+- Fixed an issue where message part of the quick reply and form template was getting truncated from the bottom.
+
 ## [5.12.0] - 2021-01-18
 
 ### Enhancements

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -334,7 +334,6 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
             } else {
                 let cell: ALKFriendMessageQuickReplyCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
                 cell.setLocalizedStringFileName(configuration.localizedStringFileName)
-                cell.update(viewModel: message)
                 cell.update(viewModel: message, maxWidth: UIScreen.main.bounds.width)
                 cell.update(chatBar: chatBar)
                 guard let template = message.payloadFromMetadata() else {

--- a/Sources/Views/ALKFriendFormCell.swift
+++ b/Sources/Views/ALKFriendFormCell.swift
@@ -30,7 +30,9 @@ class ALKFriendFormCell: ALKFormCell {
             static let maxWidth: CGFloat = 200
         }
 
-        static var maxWidth = UIScreen.main.bounds.width
+        static let maxWidth = UIScreen.main.bounds.width
+            - (ViewPadding.AvatarImageView.width + ViewPadding.AvatarImageView.leading)
+
         static let messageViewPadding = Padding(left: ChatCellPadding.ReceivedMessage.Message.left,
                                                 right: ChatCellPadding.ReceivedMessage.Message.right,
                                                 top: ChatCellPadding.ReceivedMessage.Message.top,
@@ -64,7 +66,7 @@ class ALKFriendFormCell: ALKFormCell {
     fileprivate lazy var messageView = MessageView(
         bubbleStyle: MessageTheme.receivedMessage.bubble,
         messageStyle: MessageTheme.receivedMessage.message,
-        maxWidth: ViewPadding.maxWidth
+        maxWidth: ViewPadding.maxWidth - (ViewPadding.messageViewPadding.left + ViewPadding.messageViewPadding.right)
     )
 
     fileprivate var submitButtonView = UIView(frame: .zero)

--- a/Sources/Views/ALKFriendGenericCardMessageCell.swift
+++ b/Sources/Views/ALKFriendGenericCardMessageCell.swift
@@ -32,6 +32,7 @@ open class ALKFriendGenericCardMessageCell: ALKGenericCardBaseCell {
         }
 
         static let maxWidth = UIScreen.main.bounds.width
+            - (ViewPadding.AvatarImageView.width + ViewPadding.AvatarImageView.leading)
         static let messageViewPadding = Padding(left: ChatCellPadding.ReceivedMessage.Message.left,
                                                 right: ChatCellPadding.ReceivedMessage.Message.right,
                                                 top: ChatCellPadding.ReceivedMessage.Message.top,
@@ -68,7 +69,7 @@ open class ALKFriendGenericCardMessageCell: ALKGenericCardBaseCell {
     fileprivate lazy var messageView = MessageView(
         bubbleStyle: MessageTheme.receivedMessage.bubble,
         messageStyle: MessageTheme.receivedMessage.message,
-        maxWidth: ViewPadding.maxWidth
+        maxWidth: ViewPadding.maxWidth - (ViewPadding.messageViewPadding.left + ViewPadding.messageViewPadding.right)
     )
     // fileprivate var messageViewPadding: Padding
     lazy var messageViewHeight = self.messageView.heightAnchor.constraint(equalToConstant: 0)

--- a/Sources/Views/ALKFriendMessageQuickReplyCell.swift
+++ b/Sources/Views/ALKFriendMessageQuickReplyCell.swift
@@ -29,6 +29,7 @@ public class ALKFriendMessageQuickReplyCell: ALKChatBaseCell<ALKMessageViewModel
         }
 
         static let maxWidth = UIScreen.main.bounds.width
+            - (ViewPadding.AvatarImageView.width + ViewPadding.AvatarImageView.leading)
         static let messageViewPadding = Padding(left: ChatCellPadding.ReceivedMessage.Message.left,
                                                 right: ChatCellPadding.ReceivedMessage.Message.right,
                                                 top: ChatCellPadding.ReceivedMessage.Message.top,
@@ -65,7 +66,7 @@ public class ALKFriendMessageQuickReplyCell: ALKChatBaseCell<ALKMessageViewModel
     fileprivate lazy var messageView = MessageView(
         bubbleStyle: MessageTheme.receivedMessage.bubble,
         messageStyle: MessageTheme.receivedMessage.message,
-        maxWidth: ViewPadding.maxWidth
+        maxWidth: ViewPadding.maxWidth - (ViewPadding.messageViewPadding.left + ViewPadding.messageViewPadding.right)
     )
 
     var quickReplyView = SuggestedReplyView()


### PR DESCRIPTION
## Summary
- Fixed an issue where message part of the quick reply and form template was getting truncated from the bottom.
- Also, removed extra `cell.update(viewModel: message)` call from quick reply cell.

## Motivation
To show full message in templates.

## Testing
Checked message rendering of different quick reply and form template messages.