### PR TITLE
Fixed an back button issue on direct chat launch #trivial 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ## [Unreleased]
 
 ### Enhancements
-- Added the group description support 
+
+- Added the group description support.
+
+### Fixes
+
+- Fixed an issue where back button was not visible for direct launch of one to one or group chat.
 
 ## [6.0.0] - 2021-04-12
 

--- a/Demo/ApplozicSwiftDemo/ALChatManager.swift
+++ b/Demo/ApplozicSwiftDemo/ALChatManager.swift
@@ -137,6 +137,7 @@ class ALChatManager: NSObject {
 
     func launch(viewController: UIViewController, from vc: UIViewController) {
         let navVC = ALKBaseNavigationViewController(rootViewController: viewController)
+        navVC.modalPresentationStyle = .fullScreen
         guard vc.navigationController != nil else {
             vc.present(navVC, animated: true, completion: nil)
             return

--- a/Sources/Controllers/ALKBaseViewController.swift
+++ b/Sources/Controllers/ALKBaseViewController.swift
@@ -26,19 +26,14 @@ open class ALKBaseViewController: UIViewController, ALKConfigurable {
 
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        /// Add the back button in case if first view controller is not same as current VC OR
-        /// Add the back button in case if first view controller is  ALKConversationViewController and current VC is ALKConversationViewController
-        if let vc = navigationController?.viewControllers.first, vc != self || vc.isKind(of: ALKConversationViewController.self) {
-            var backImage = UIImage(named: "icon_back", in: Bundle.applozic, compatibleWith: nil)
-            backImage = backImage?.imageFlippedForRightToLeftLayoutDirection()
-            let backButton = UIBarButtonItem(
-                image: backImage,
-                style: .plain,
-                target: self,
-                action: #selector(backTapped)
-            )
-            backButton.accessibilityIdentifier = "conversationBackButton"
-            navigationItem.leftBarButtonItem = backButton
+        // Add the back button in case if first view controller is nil or is not same as current VC OR
+        // Add the back button in case if first view controller is  ALKConversationViewController and current VC is ALKConversationViewController
+        if navigationController?.viewControllers.first != self {
+            navigationItem.leftBarButtonItem = backBarButtonItem()
+        } else if let vc = navigationController?.viewControllers.first,
+                  vc.isKind(of: ALKConversationViewController.self)
+        {
+            navigationItem.leftBarButtonItem = backBarButtonItem()
         }
 
         if configuration.hideNavigationBarBottomLine {
@@ -77,4 +72,17 @@ open class ALKBaseViewController: UIViewController, ALKConfigurable {
     }
 
     open func showAccountSuspensionView() {}
+
+    func backBarButtonItem() -> UIBarButtonItem {
+        var backImage = UIImage(named: "icon_back", in: Bundle.applozic, compatibleWith: nil)
+        backImage = backImage?.imageFlippedForRightToLeftLayoutDirection()
+        let backButton = UIBarButtonItem(
+            image: backImage,
+            style: .plain,
+            target: self,
+            action: #selector(backTapped)
+        )
+        backButton.accessibilityIdentifier = "conversationBackButton"
+        return backButton
+    }
 }

--- a/Sources/Controllers/ALKBaseViewController.swift
+++ b/Sources/Controllers/ALKBaseViewController.swift
@@ -26,8 +26,9 @@ open class ALKBaseViewController: UIViewController, ALKConfigurable {
 
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
-        if navigationController?.viewControllers.first != self {
+        /// Add the back button in case if first view controller is not same as current VC OR
+        /// Add the back button in case if first view controller is  ALKConversationViewController and current VC is ALKConversationViewController
+        if let vc = navigationController?.viewControllers.first, vc != self || vc.isKind(of: ALKConversationViewController.self) {
             var backImage = UIImage(named: "icon_back", in: Bundle.applozic, compatibleWith: nil)
             backImage = backImage?.imageFlippedForRightToLeftLayoutDirection()
             let backButton = UIBarButtonItem(


### PR DESCRIPTION
## Summary
Fixed a back button issue where when we launch one to one or group chat screen directly using launch methods the back button was not showing 
* Made the VC to full screen 

## Motivation
<!-- Why are you making this change? -->

## Testing
Tested by opening the one to one chat directly using launch with userId or groupId
Tested by opening the chat list screen and checked if the back button is showing fine.

Use this methods [link](https://docs.applozic.com/docs/ios-1-1-user-chat-and-group-chat#launching-chat---one-to-one-and-groups-1) for launch the one to one or group chat to check the if the back button shows fine : 


