### PR TITLE
[TD-2236] Post Submitted Form Data As Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 
 ## [Unreleased]
+- Send Post Submitted Form Data As Message
 
 ## [6.4.0] - 2021-09-28
 

--- a/Sources/Models/FormTemplate.swift
+++ b/Sources/Models/FormTemplate.swift
@@ -27,7 +27,7 @@ struct FormTemplate: Decodable {
     }
 
     struct Action: Decodable {
-        let formAction, message, requestType: String?
+        let formAction, message, requestType: String?,postFormDataAsMessage: String?
     }
 
     struct Validation: Decodable {


### PR DESCRIPTION
## Summary
This PR for the feature Post submitted form data can also be sent as message based on a flag `postFormDataAsMessage`.

This flag will be there inside the Action object of submit button. For example 
` 

           {
               "type": "submit",
                "data": {
                    "action": {
                        "message": "optional- this message will be used as acknowledgement text when user clicks the button",
                        "requestType": "postBackToBotPlatform",
                        "postFormDataAsMessage" : "true"
                        "formAction": "<URL>"
                    },
                    "type": "submit",
                    "name": "Submit"
          }
`

<img src="https://user-images.githubusercontent.com/61688116/138079545-7b01856f-27cb-4bc0-86c5-43bdf3ea6dae.png" alt="alt text" width="250" height="350">

Note:
  This is already done in Android as well as web sdk.