### PR TITLE
[CM-716] RTL Support  in iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 
 ## [Unreleased]
+- Added Support for RTL Languages
 
 ## [6.4.0] - 2021-09-28
 

--- a/Sources/Controllers/ALKBaseViewController.swift
+++ b/Sources/Controllers/ALKBaseViewController.swift
@@ -49,13 +49,10 @@ open class ALKBaseViewController: UIViewController, ALKConfigurable {
     
     func checkForLanguageDirection(){
         let language = NSLocale.preferredLanguages[0]
-        let laguageArray = language.split(separator: "-")
-        if laguageArray.count > 0 {
-            let lanCode = laguageArray[0]
-            if (lanCode == "ar" || lanCode == "he" || lanCode == "fa") {
-                UIView.appearance().semanticContentAttribute = .forceRightToLeft
-
-            }
+        let direction = NSLocale.characterDirection(forLanguage: language)
+      
+        if direction == NSLocale.LanguageDirection.rightToLeft {
+            UIView.appearance().semanticContentAttribute = .forceRightToLeft
         }
     }
 

--- a/Sources/Controllers/ALKBaseViewController.swift
+++ b/Sources/Controllers/ALKBaseViewController.swift
@@ -44,6 +44,19 @@ open class ALKBaseViewController: UIViewController, ALKConfigurable {
     override open func viewDidLoad() {
         super.viewDidLoad()
         checkPricingPackage()
+        checkForLanguageDirection()
+    }
+    
+    func checkForLanguageDirection(){
+        let language = NSLocale.preferredLanguages[0]
+        let laguageArray = language.split(separator: "-")
+        if laguageArray.count > 0 {
+            let lanCode = laguageArray[0]
+            if (lanCode == "ar" || lanCode == "he" || lanCode == "fa") {
+                UIView.appearance().semanticContentAttribute = .forceRightToLeft
+
+            }
+        }
     }
 
     @objc func backTapped() {


### PR DESCRIPTION
## Summary
Providing `RTL Support` for iOS sdk. Sdk will change layout view's direction if the preferred language belongs RTL.

## Motivation
This feature is already there in Android SDK.Now have been implemented in iOS SDK.

## Testing
1. Have tested locally in the simulator by changing device language to Arabic.