### PR TITLE
[CM-734] iOS Firebase crash report | ALKConversationViewController.swift line 1940

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 
 
 ## [Unreleased]
-
+- Fixed Update Tableview Crash on new message arrival
 ## [6.4.0] - 2021-09-28
 
 ### Project

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1923,7 +1923,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
     func updateTableView() {
         let oldCount = tableView.numberOfSections
         let newCount = viewModel.numberOfSections()
-        guard newCount >= oldCount else {
+        guard newCount > oldCount else {
             tableView.reloadData()
             print("😱Tableview shouldn't have more number of sections than viewModel😱")
             return


### PR DESCRIPTION
## Summary
Updating Tableview  getting crashing sometime. I am getting crash message as 
`Fatal Exception: NSInternalInconsistencyException
attempt to delete section 5, but there are only 5 sections before the update
ALKConversationViewController.updateTableView()
keyboard_arrow_down
`
### Firebase Crashlytics Link
[https://console.firebase.google.com/u/0/project/kommunicate-c6413/crashlytics/app/ios:io.kommunicate.agent/issues/349b3f2307bb499ee802dc32229c9c33?time=last-thirty-days&sessionEventKey=fef7ff54f1d045569082968115bab7b6_1607129342567774982](https://console.firebase.google.com/u/0/project/kommunicate-c6413/crashlytics/app/ios:io.kommunicate.agent/issues/349b3f2307bb499ee802dc32229c9c33?time=last-thirty-days&sessionEventKey=fef7ff54f1d045569082968115bab7b6_1607129342567774982)

## Testing
Locally Tested the solution , updating Table view is not crashing as well as working correctly without any issues.