### PR TITLE
[CM-709] iOS Event Listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for [ApplozicSwift](https://github.com/AppLozic/ApplozicSwift). Al
 ## [Unreleased]
 
 - Added support for text areas in rich message forms
+- Added support for sending chat widget events to User.
 
 ## [6.4.0] - 2021-09-28
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1259,6 +1259,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         else {
             return
         }
+        ALKCustomEventHandler.trackEvent(trackingevent: ALKCustomEventHandler.ON_RICH_MESSAGE_CLICK, value: title)
         switch type {
         case "link":
             linkButtonSelected(action)

--- a/Sources/CustomEvent/ALKCustomEvent.swift
+++ b/Sources/CustomEvent/ALKCustomEvent.swift
@@ -1,0 +1,18 @@
+//
+//
+// ALKCustomEvent.swift
+// ApplozicSwift
+//
+// Created by ___Sathyan Elangovan___ on 09/12/21
+import Foundation
+open class ALKCustomEvent {
+    public var eventName: String
+    public var data: ALKCustomEventData?
+    public var callback: ALKCustomEventCallback?
+
+    public init (eventName: String, eventData: ALKCustomEventData?,eventCallBack: ALKCustomEventCallback?){
+        self.eventName = eventName
+        self.data = eventData
+        self.callback = eventCallBack
+    }
+}

--- a/Sources/CustomEvent/ALKCustomEventCallback.swift
+++ b/Sources/CustomEvent/ALKCustomEventCallback.swift
@@ -1,0 +1,10 @@
+//
+//
+// ALKCustomEventCallback.swift
+// ApplozicSwift
+//
+// Created by ___Sathyan Elangovan___ on 09/12/21
+import Foundation
+public protocol ALKCustomEventCallback {
+    func eventTriggered(eventType: String,data: ALKCustomEventData)
+}

--- a/Sources/CustomEvent/ALKCustomEventData.swift
+++ b/Sources/CustomEvent/ALKCustomEventData.swift
@@ -1,0 +1,21 @@
+//
+//
+// ALKCustomEventData.swift
+// ApplozicSwift
+//
+// Created by ___Sathyan Elangovan___ on 09/12/21
+import Foundation
+open class ALKCustomEventData: Decodable {
+    var eventCategory: String
+    var eventAction: String
+    var eventLabel: String
+    var eventValue: String?
+    public init(eventCategory: String,eventAction: String, eventLabel: String ) {
+        self.eventLabel = eventLabel
+        self.eventCategory = eventCategory
+        self.eventAction = eventAction
+    }
+    public func updateLabel(updatedLabel: String) {
+        self.eventLabel = updatedLabel
+    }
+}

--- a/Sources/CustomEvent/ALKCustomEventHandler.swift
+++ b/Sources/CustomEvent/ALKCustomEventHandler.swift
@@ -1,0 +1,88 @@
+//
+//
+// ALKCustomEventHandler.swift
+// ApplozicSwift
+//
+// Created by ___Sathyan Elangovan___ on 09/12/21
+import Foundation
+open class ALKCustomEventHandler {
+    public static func trackEvent(trackingevent: ALKCustomEvent, value: String?) {
+        guard let event = subscribedEvents[trackingevent.eventName] else {
+                print("Event is not subscribed")
+                return
+            }
+            if trackingevent.eventName == ALKCustomEventMap.EVENT_ON_RATE_CONVERSATION_EMOTIONS_CLICK{
+                switch value {
+                case "1":
+                    trackingevent.data!.updateLabel(updatedLabel:CSAT_POOR)
+                case "5":
+                    trackingevent.data!.updateLabel(updatedLabel:CSAT_AVERAGE)
+                case "10":
+                    trackingevent.data!.updateLabel(updatedLabel:CSAT_POOR)
+                default:
+                    trackingevent.data!.updateLabel(updatedLabel:CSAT_POOR)
+
+                }
+                trackingevent.data?.eventValue = value
+            }
+            if let callback = event.callback {
+                callback.eventTriggered(eventType:event.eventName ,data: trackingevent.data!)
+            }
+
+    }
+    public static let eventCategory:String = "Kommunicate"
+    public static let actionClick = "Click"
+    public static let actionSent = "Sent"
+    public static let actionOpen = "Open"
+    public static let actionClose = "Close"
+    public static let actionStart = "Start"
+    public static let actionStarted = "Started"
+    public static let actionRestart = "Restart"
+    public static let actionRichClick = "Rich message Click"
+    public static let actionSubmit = "Submit"
+    public static let actionRate = "Rate"
+    public static let actionStartNew = "Start New"
+    // VALUES
+    public static  let GALLERY_SECTION = "GALLERY"
+    public static  let VIDEO_SECTION = "VIDEO"
+    public static  let CAMERA_SECTION = "CAMERA"
+    public static  let DOCUMENT_SECTION = "DOCUMENT"
+    public static  let CONTACT_SECTION = "CONTACT"
+    // CAST VALUES
+    public static let CSAT_POOR = "CSAT Rate Poor"
+    public static let CSAT_AVERAGE = "CSAT Rate Average"
+    public static let CSAT_GREAT = "CSAT Rate Great"
+   // labels
+//    static let LABEL_ATTACHMEN
+
+    public static let ON_ATTACHMENT_ICON_CLICK = ALKCustomEvent(eventName:ALKCustomEventMap.EVENT_ON_ATTACHMENT_ICON_CLICK ,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionClick, eventLabel: "Attachment"),eventCallBack: nil)
+
+    public static let ON_LOCATION_ICON_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_LOCATION_ICON_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionClick, eventLabel: "Location"),eventCallBack: nil)
+    public static let ON_MESSAGE_SEND = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_MESSAGE_SEND,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionSent, eventLabel: "Message"), eventCallBack: nil)
+//
+    public static let ON_FAQ_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_FAQ_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionClick, eventLabel: "FAQ Menu"),eventCallBack: nil)
+    public static let ON_GREETING_MESSAGE_NOTIFICATION_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_GREETING_MESSAGE_NOTIFICATION_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionClick, eventLabel: "Greeting"),eventCallBack: nil)
+    public static let ON_NOTIFICATION_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_NOTIFICATION_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionClick, eventLabel: "Notification"),eventCallBack: nil)
+    public static let ON_RESOLVE_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_RESOLVE_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionClick, eventLabel: "Show Resolve"),eventCallBack: nil)
+    public static let ON_START_NEW_CONVERSATION_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_START_NEW_CONVERSATION_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionStartNew, eventLabel: "Conversation Start"),eventCallBack: nil)
+//    static let ON_ATTACHMENT_ICON_CLICK = KMCustomEvent(eventName: Kommunicate.EVENT_ON_ATTACHMENT_ICON_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionClick, eventLabel: "Attachment"),eventCallBack: nil)
+    public static let ON_VOICE_ICON_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_VOICE_ICON_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionClick, eventLabel: "Voice Input"),eventCallBack: nil)
+    public static let ON_RATE_CONVERSATION_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_RATE_CONVERSATION_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionStarted, eventLabel: "CSAT Start"),eventCallBack: nil)
+    public static var ON_RATE_CONVERSATION_EMOTIONS_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_RATE_CONVERSATION_EMOTIONS_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionRate, eventLabel: "CSAT Rate Poor"),eventCallBack: nil)
+    public static let ON_SUBMIT_RATING_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_SUBMIT_RATING_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionSubmit, eventLabel: "CSAT Submit"),eventCallBack: nil)
+    public static let ON_CHAT_CLOSE_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_CHAT_CLOSE_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionClose, eventLabel: "Chat Widget Close"),eventCallBack: nil)
+    public static let ON_CHAT_OPEN_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_CHAT_OPEN_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionOpen, eventLabel: "Chat Widget Open"),eventCallBack: nil)
+    public static let ON_RESTART_CONVERSATION_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_RESTART_CONVERSATION_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionRestart, eventLabel: "Conversation Restart"),eventCallBack: nil)
+    public static var ON_RICH_MESSAGE_CLICK = ALKCustomEvent(eventName: ALKCustomEventMap.EVENT_ON_RICH_MESSAGE_CLICK,eventData: ALKCustomEventData(eventCategory: eventCategory, eventAction: actionRichClick, eventLabel: "Chat Widget Close"),eventCallBack: nil)
+    public static var subscribedEvents = [String:ALKCustomEvent]()
+
+    public static func setSubscribedEvents(eventsList: [ALKCustomEvent]){
+        if !eventsList.isEmpty {
+            for event in eventsList {
+                subscribedEvents[event.eventName] = event
+            }
+        } else {
+            print("Subscribe Event List is Nil")
+        }
+    }
+}

--- a/Sources/CustomEvent/ALKCustomEventMap.swift
+++ b/Sources/CustomEvent/ALKCustomEventMap.swift
@@ -1,14 +1,11 @@
 //
-        //
-        // ALKCustomEventMap.swift
-        // ApplozicSwift
-        //
-        // Created by ___Sathyan Elangovan___ on 09/12/21
-       
-    
-
+//
+// ALKCustomEventMap.swift
+// ApplozicSwift
+//
+// Created by ___Sathyan Elangovan___ on 09/12/21
 import Foundation
-struct ALKCustomEventMap {
+public struct ALKCustomEventMap {
     public static let EVENT_ON_MESSAGE_SEND: String = "ON_MESSAGE_SEND"
     public static let EVENT_ON_FAQ_CLICK: String = "ON_FAQ_CLICK"
     public static let EVENT_ON_GREETING_MESSAGE_NOTIFICATION_CLICK: String = "ON_GREETING_MESSAGE_NOTIFICATION_CLICK"

--- a/Sources/CustomEvent/ALKCustomEventMap.swift
+++ b/Sources/CustomEvent/ALKCustomEventMap.swift
@@ -1,0 +1,28 @@
+//
+        //
+        // ALKCustomEventMap.swift
+        // ApplozicSwift
+        //
+        // Created by ___Sathyan Elangovan___ on 09/12/21
+       
+    
+
+import Foundation
+struct ALKCustomEventMap {
+    public static let EVENT_ON_MESSAGE_SEND: String = "ON_MESSAGE_SEND"
+    public static let EVENT_ON_FAQ_CLICK: String = "ON_FAQ_CLICK"
+    public static let EVENT_ON_GREETING_MESSAGE_NOTIFICATION_CLICK: String = "ON_GREETING_MESSAGE_NOTIFICATION_CLICK"
+    public static let EVENT_ON_NOTIFICATION_CLICK: String = "ON_NOTIFICATION_CLICK"
+    public static let EVENT_ON_RESOLVE_CLICK: String = "ON_RESOLVE_CLICK"
+    public static let EVENT_ON_START_NEW_CONVERSATION_CLICK: String = "ON_START_NEW_CONVERSATION_CLICK"
+    public static let EVENT_ON_ATTACHMENT_ICON_CLICK: String = "ON_ATTACHMENT_ICON_CLICK"
+    public static let EVENT_ON_VOICE_ICON_CLICK: String = "ON_VOICE_ICON_CLICK"
+    public static let EVENT_ON_LOCATION_ICON_CLICK: String = "ON_LOCATION_ICON_CLICK"
+    public static let EVENT_ON_RATE_CONVERSATION_CLICK: String = "ON_RATE_CONVERSATION_CLICK"
+    public static let EVENT_ON_RATE_CONVERSATION_EMOTIONS_CLICK: String = "ON_RATE_CONVERSATION_EMOTIONS_CLICK"
+    public static let EVENT_ON_SUBMIT_RATING_CLICK: String = "ON_SUBMIT_RATING_CLICK"
+    public static let EVENT_ON_CHAT_CLOSE_CLICK: String = "ON_CHAT_CLOSE_CLICK"
+    public static let EVENT_ON_CHAT_OPEN_CLICK: String = "ON_CHAT_OPEN_CLICK"
+    public static let EVENT_ON_RESTART_CONVERSATION_CLICK: String = "ON_RESTART_CONVERSATION_CLICK"
+    public static let EVENT_ON_RICH_MESSAGE_CLICK: String = "ON_RICH_MESSAGE_CLICK"
+}

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -677,6 +677,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
     }
 
     open func send(message: String, isOpenGroup: Bool = false, metadata: [AnyHashable: Any]?) {
+        ALKCustomEventHandler.trackEvent(trackingevent: ALKCustomEventHandler.ON_MESSAGE_SEND, value: nil)
         let alMessage = getMessageToPost(isTextMessage: true)
         alMessage.message = message
         alMessage.metadata = modfiedMessageMetadata(alMessage: alMessage, metadata: metadata)

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -280,16 +280,22 @@ open class ALKChatBar: UIView, Localizable {
         case plusButton:
             action?(.more(button))
         case photoButton:
+            ALKCustomEventHandler.trackEvent(trackingevent: ALKCustomEventHandler.ON_ATTACHMENT_ICON_CLICK, value: ALKCustomEventHandler.CAMERA_SECTION)
             action?(.cameraButtonClicked(button))
         case videoButton:
+            ALKCustomEventHandler.trackEvent(trackingevent: ALKCustomEventHandler.ON_ATTACHMENT_ICON_CLICK, value: ALKCustomEventHandler.VIDEO_SECTION)
             action?(.startVideoRecord)
         case galleryButton:
+            ALKCustomEventHandler.trackEvent(trackingevent: ALKCustomEventHandler.ON_ATTACHMENT_ICON_CLICK, value: ALKCustomEventHandler.GALLERY_SECTION)
             action?(.showImagePicker)
         case locationButton:
+            ALKCustomEventHandler.trackEvent(trackingevent: ALKCustomEventHandler.ON_LOCATION_ICON_CLICK, value: nil)
             action?(.showLocation)
         case contactButton:
+            ALKCustomEventHandler.trackEvent(trackingevent: ALKCustomEventHandler.ON_ATTACHMENT_ICON_CLICK, value: ALKCustomEventHandler.CONTACT_SECTION)
             action?(.shareContact)
         case documentButton:
+            ALKCustomEventHandler.trackEvent(trackingevent: ALKCustomEventHandler.ON_ATTACHMENT_ICON_CLICK, value: ALKCustomEventHandler.DOCUMENT_SECTION)
             action?(.showDocumentPicker)
         default: break
         }

--- a/Sources/Views/AudioRecordButton.swift
+++ b/Sources/Views/AudioRecordButton.swift
@@ -168,6 +168,7 @@ open class AudioRecordButton: UIButton {
 
         switch gesture.state {
         case .began:
+            ALKCustomEventHandler.trackEvent(trackingevent: ALKCustomEventHandler.ON_VOICE_ICON_CLICK, value: nil)
             if checkMicrophonePermission() == false {
                 delegate?.permissionNotGrant()
             } else {


### PR DESCRIPTION
## Summary
To send [events](https://kommunicate.atlassian.net/wiki/spaces/TKB/pages/591626293/Google+Analytics+Event+for+Chat+Widget) which are happening inside the chat widget to user.

## Testing
I have tested locally for all the events.